### PR TITLE
43 aditional characteristics to task

### DIFF
--- a/pallets/task/src/benchmarking.rs
+++ b/pallets/task/src/benchmarking.rs
@@ -34,35 +34,6 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
-// This creates and returns a `Task` object.
-fn create_task_info<T: Config>(_num_fields: u32) -> Task<T> {
-
-	// Populate with worst case scenario
-	let mut data = Vec::new();
-	data.push(u8::MAX);
-
-	// Populate data fields
-	let initiator: T::AccountId = whitelisted_caller();
-	let volunteer: T::AccountId = whitelisted_caller();
-	let owner: T::AccountId = whitelisted_caller();
-	let balance = <T as pallet::Config>::Currency::total_balance(&initiator);
-	let deadline = u64::MAX;
-	let status: TaskStatus = TaskStatus::InProgress;
-
-	// Create object
-	let info = Task {
-		title: data.clone(),
-		specification: data.clone(),
-		initiator: initiator,
-		volunteer: volunteer,
-		current_owner: owner,
-		status: status,
-		budget: balance,
-		deadline: deadline,
-	};
-
-	return info
-}
 
 // Helper function to create a profile
 fn create_profile<T: Config>(){
@@ -87,15 +58,17 @@ benchmarks! {
 		let x in 1 .. 2000;
 		let title = vec![0u8, s as u8];
 		let specification = vec![0u8, s as u8];
+		let attachments = vec![0u8, s as u8];
+		let keywords = vec![0u8, s as u8];
+		
 		let budget = <T as pallet::Config>::Currency::total_balance(&caller);
 
 		// Create profile before creating a task
 		create_profile::<T>();
-		create_task_info::<T>(1);
 
 	}:
 	/* the code to be benchmarked */
-	create_task(RawOrigin::Signed(caller.clone()), title, specification, budget, x.into())
+	create_task(RawOrigin::Signed(caller.clone()), title.try_into().unwrap(), specification.try_into().unwrap(), budget, x.into(), attachments.try_into().unwrap(), keywords.try_into().unwrap())
 
 	verify {
 		/* verifying final state */
@@ -115,16 +88,17 @@ benchmarks! {
 		let title = vec![0u8, s as u8];
 		let specification = vec![0u8, s as u8];
 		let budget = <T as pallet::Config>::Currency::total_balance(&caller);
+		let attachments = vec![0u8, s as u8];
+		let keywords = vec![0u8, s as u8];
 
 		// Create profile before creating a task
 		create_profile::<T>();
-		create_task_info::<T>(1);
-		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(caller.clone()).into(), title.clone(), specification.clone(), budget, x.into());
+		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(caller.clone()).into(), title.clone().try_into().unwrap(), specification.clone().try_into().unwrap(), budget, x.into(), attachments.clone().try_into().unwrap(), keywords.clone().try_into().unwrap());
 		let hash_task = PalletTask::<T>::tasks_owned(&caller)[0];
 
 	}:
 	/* the code to be benchmarked */
-	update_task(RawOrigin::Signed(caller.clone()), hash_task, title, specification, budget, x.into())
+	update_task(RawOrigin::Signed(caller.clone()), hash_task, title.try_into().unwrap(), specification.try_into().unwrap(), budget, x.into(), attachments.try_into().unwrap(), keywords.try_into().unwrap())
 
 	verify {
 		/* verifying final state */
@@ -145,10 +119,12 @@ benchmarks! {
 		let title = vec![0u8, s as u8];
 		let specification = vec![0u8, s as u8];
 		let budget = <T as pallet::Config>::Currency::total_balance(&task_creator);
+		let attachments = vec![0u8, s as u8];
+		let keywords = vec![0u8, s as u8];
 
 		// Create profile before creating a task
 		create_profile::<T>();
-		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(task_creator.clone()).into(), title, specification, budget, x.into());
+		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(task_creator.clone()).into(), title.try_into().unwrap(), specification.try_into().unwrap(), budget, x.into(), attachments.try_into().unwrap(), keywords.try_into().unwrap());
 		let hash_task = PalletTask::<T>::tasks_owned(&task_creator)[0];
 
 	}: start_task(RawOrigin::Signed(volunteer.clone()), hash_task)
@@ -170,10 +146,12 @@ benchmarks! {
 		let title = vec![0u8, s as u8];
 		let specification = vec![0u8, s as u8];
 		let budget = <T as pallet::Config>::Currency::total_balance(&task_creator);
+		let attachments = vec![0u8, s as u8];
+		let keywords = vec![0u8, s as u8];
 
 		// Create profile before creating a task
 		create_profile::<T>();
-		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(task_creator.clone()).into(), title, specification, budget, x.into());
+		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(task_creator.clone()).into(), title.try_into().unwrap(), specification.try_into().unwrap(), budget, x.into(), attachments.try_into().unwrap(), keywords.try_into().unwrap());
 		let hash_task = PalletTask::<T>::tasks_owned(&task_creator)[0];
 
 	}: remove_task(RawOrigin::Signed(task_creator.clone()), hash_task)
@@ -195,10 +173,12 @@ benchmarks! {
 		let title = vec![0u8, s as u8];
 		let specification = vec![0u8, s as u8];
 		let budget = <T as pallet::Config>::Currency::total_balance(&task_creator);
+		let attachments = vec![0u8, s as u8];
+		let keywords = vec![0u8, s as u8];
 
 		// Create profile before creating a task
 		create_profile::<T>();
-		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(task_creator.clone()).into(), title, specification, budget, x.into());
+		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(task_creator.clone()).into(), title.try_into().unwrap(), specification.try_into().unwrap(), budget, x.into(), attachments.try_into().unwrap(), keywords.try_into().unwrap());
 		let hash_task = PalletTask::<T>::tasks_owned(&task_creator)[0];
 		let _ = PalletTask::<T>::start_task(RawOrigin::Signed(volunteer.clone()).into(), hash_task.clone());
 
@@ -221,10 +201,12 @@ benchmarks! {
 		let title = vec![0u8, s as u8];
 		let specification = vec![0u8, s as u8];
 		let budget = <T as pallet::Config>::Currency::total_balance(&task_creator);
+		let attachments = vec![0u8, s as u8];
+		let keywords = vec![0u8, s as u8];
 
 		// Create profile before creating a task
 		create_profile::<T>();
-		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(task_creator.clone()).into(), title, specification, budget, x.into());
+		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(task_creator.clone()).into(), title.try_into().unwrap(), specification.try_into().unwrap(), budget, x.into(), attachments.try_into().unwrap(), keywords.try_into().unwrap());
 		let hash_task = PalletTask::<T>::tasks_owned(&task_creator)[0];
 		let _ = PalletTask::<T>::start_task(RawOrigin::Signed(volunteer.clone()).into(), hash_task.clone());
 		let _ = PalletTask::<T>::complete_task(RawOrigin::Signed(volunteer.clone()).into(), hash_task.clone());
@@ -247,16 +229,20 @@ benchmarks! {
 		let x in 1 .. 4000;
 		let title = vec![0u8, s as u8];
 		let specification = vec![0u8, s as u8];
+		let feedback = vec![0u8, s as u8];
 		let budget = <T as pallet::Config>::Currency::total_balance(&task_creator);
+		let attachments = vec![0u8, s as u8];
+		let keywords = vec![0u8, s as u8];
+		let feedback = vec![0u8, s as u8];
 
 		// Create profile before creating a task
 		create_profile::<T>();
-		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(task_creator.clone()).into(), title, specification, budget, x.into());
+		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(task_creator.clone()).into(), title.try_into().unwrap(), specification.try_into().unwrap(), budget, x.into(), attachments.try_into().unwrap(), keywords.try_into().unwrap());
 		let hash_task = PalletTask::<T>::tasks_owned(&task_creator)[0];
 		let _ = PalletTask::<T>::start_task(RawOrigin::Signed(volunteer.clone()).into(), hash_task.clone());
 		let _ = PalletTask::<T>::complete_task(RawOrigin::Signed(volunteer.clone()).into(), hash_task.clone());
 
-	}: reject_task(RawOrigin::Signed(task_creator.clone()), hash_task)
+	}: reject_task(RawOrigin::Signed(task_creator.clone()), hash_task, feedback.try_into().unwrap())
 		/* the code to be benchmarked */
 
 	verify {

--- a/pallets/task/src/lib.rs
+++ b/pallets/task/src/lib.rs
@@ -130,14 +130,20 @@ pub mod pallet {
 	#[derive(Clone, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
 	#[scale_info(skip_type_params(T))]
 	pub struct Task<T: Config> {
-		pub title: Vec<u8>,
-		pub specification: Vec<u8>,
+		pub title: BoundedVec<u8, T::MaxTitleLen>,
+		pub specification: BoundedVec<u8, T::MaxSpecificationLen>,
 		pub initiator: AccountOf<T>,
 		pub volunteer: AccountOf<T>,
 		pub current_owner: AccountOf<T>,
 		pub status: TaskStatus,
 		pub budget: BalanceOf<T>,
 		pub deadline: u64,
+		pub attachments: BoundedVec<u8, T::MaxAttachmentsLen>,
+		pub keywords: BoundedVec<u8, T::MaxKeywordsLen>,
+		pub feedback: BoundedVec<u8, T::MaxFeedbackLen>,
+		pub created_at: <T as frame_system::Config>::BlockNumber,
+		pub updated_at:<T as frame_system::Config>::BlockNumber,
+		pub completed_at: <T as frame_system::Config>::BlockNumber,
 	}
 
 	// Set TaskStatus enum.
@@ -166,6 +172,21 @@ pub mod pallet {
 		/// The maximum amount of tasks a single account can own.
 		#[pallet::constant]
 		type MaxTasksOwned: Get<u32>;
+
+		#[pallet::constant]
+		type MaxTitleLen: Get<u32> + MaxEncodedLen + TypeInfo;
+
+		#[pallet::constant]
+		type MaxSpecificationLen: Get<u32> + MaxEncodedLen + TypeInfo;
+
+		#[pallet::constant]
+		type MaxAttachmentsLen: Get<u32> + MaxEncodedLen + TypeInfo;
+
+		#[pallet::constant]
+		type MaxFeedbackLen: Get<u32> + MaxEncodedLen + TypeInfo;
+
+		#[pallet::constant]
+		type MaxKeywordsLen: Get<u32> + MaxEncodedLen + TypeInfo;
 
 		/// WeightInfo provider.
 		type WeightInfo: WeightInfo;
@@ -258,13 +279,14 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Function call that creates tasks.  [ origin, specification, budget, deadline]
 		#[pallet::weight(<T as Config>::WeightInfo::create_task(0,0))]
-		pub fn create_task(origin: OriginFor<T>, title: Vec<u8>, specification: Vec<u8>, budget: BalanceOf<T>, deadline: u64) -> DispatchResultWithPostInfo {
+		pub fn create_task(origin: OriginFor<T>, title: BoundedVec<u8, T::MaxTitleLen>, specification: BoundedVec<u8, T::MaxSpecificationLen>, budget: BalanceOf<T>, 
+			deadline: u64, attachments: BoundedVec<u8, T::MaxAttachmentsLen>, keywords: BoundedVec<u8, T::MaxKeywordsLen>, feedback: BoundedVec<u8, T::MaxFeedbackLen>) -> DispatchResultWithPostInfo {
 
 			// Check that the extrinsic was signed and get the signer.
 			let signer = ensure_signed(origin)?;
 
 			// Update storage.
-			let task_id = Self::new_task(&signer, &title, &specification, &budget, deadline)?;
+			let task_id = Self::new_task(&signer, title, specification, &budget, deadline, attachments, keywords, feedback)?;
 
 			// Transfer balance amount to escrow account
 			let sub_account = Self::account_id(&task_id);
@@ -280,13 +302,14 @@ pub mod pallet {
 		/// Function call that updates a created task.  [ origin, specification, budget, deadline]
 		/// Note: budget specified in this call is added to budget provided in create_task() call.
 		#[pallet::weight(<T as Config>::WeightInfo::update_task(0,0))]
-		pub fn update_task(origin: OriginFor<T>, task_id: T::Hash, title: Vec<u8>, specification: Vec<u8>, budget: BalanceOf<T>, deadline: u64) -> DispatchResultWithPostInfo {
+		pub fn update_task(origin: OriginFor<T>, task_id: T::Hash, title: BoundedVec<u8, T::MaxTitleLen>, specification: BoundedVec<u8, T::MaxSpecificationLen>, 
+			budget: BalanceOf<T>, deadline: u64, attachments: BoundedVec<u8, T::MaxAttachmentsLen>, keywords: BoundedVec<u8, T::MaxKeywordsLen>, feedback: BoundedVec<u8, T::MaxFeedbackLen>) -> DispatchResultWithPostInfo {
 
 			// Check that the extrinsic was signed and get the signer.
 			let signer = ensure_signed(origin)?;
 
 			// Update storage.
-			let _task_id = Self::update_created_task(&signer, &task_id, &title, &specification, &budget, deadline)?;
+			let _task_id = Self::update_created_task(&signer, &task_id, title, specification, &budget, deadline, attachments, keywords, feedback)?;
 
 			// Update balance of escrow account
 			let sub_account = Self::account_id(&task_id);
@@ -425,7 +448,8 @@ pub mod pallet {
 	// *** Helper functions *** //
 	impl<T:Config> Pallet<T> {
 
-		pub fn new_task(from_initiator: &T::AccountId, title: &[u8], specification: &[u8], budget: &BalanceOf<T>, deadline: u64) -> Result<T::Hash, DispatchError> {
+		pub fn new_task(from_initiator: &T::AccountId, title: BoundedVec<u8, T::MaxTitleLen>, specification: BoundedVec<u8, T::MaxSpecificationLen>, budget: &BalanceOf<T>,
+			 deadline: u64, attachments: BoundedVec<u8, T::MaxAttachmentsLen>, keywords: BoundedVec<u8, T::MaxKeywordsLen>, feedback: BoundedVec<u8, T::MaxFeedbackLen>) -> Result<T::Hash, DispatchError> {
 
 			// Ensure user has a profile before creating a task
 			ensure!(pallet_profile::Pallet::<T>::has_profile(from_initiator).unwrap(), <Error<T>>::NoProfile);
@@ -434,14 +458,20 @@ pub mod pallet {
 
 			// Init Task Object
 			let task = Task::<T> {
-				title: title.to_vec(),
-				specification: specification.to_vec(),
+				title,
+				specification,
 				initiator: from_initiator.clone(),
 				volunteer: from_initiator.clone(),
 				status: Created,
 				budget: *budget,
 				current_owner: from_initiator.clone(),
 				deadline,
+				attachments,
+				keywords,
+				feedback,
+				created_at: <frame_system::Pallet<T>>::block_number(),
+				updated_at: Default::default(),
+				completed_at: Default::default(),
 			};
 
 			// Create hash of task
@@ -463,7 +493,8 @@ pub mod pallet {
 		}
 
 		// Task can be updated only after it has been created. Task that is already in progress can't be updated.
-		pub fn update_created_task(from_initiator: &T::AccountId, task_id: &T::Hash, new_title: &[u8], new_specification: &[u8], new_budget: &BalanceOf<T>, new_deadline: u64) -> Result<(), DispatchError> {
+		pub fn update_created_task(from_initiator: &T::AccountId, task_id: &T::Hash, new_title: BoundedVec<u8, T::MaxTitleLen>, new_specification: BoundedVec<u8, T::MaxSpecificationLen>, new_budget: &BalanceOf<T>, 
+			new_deadline: u64, attachments: BoundedVec<u8, T::MaxAttachmentsLen>, keywords: BoundedVec<u8, T::MaxKeywordsLen>, feedback: BoundedVec<u8, T::MaxFeedbackLen>) -> Result<(), DispatchError> {
 
 			// Check if task exists
 			let mut task = Self::tasks(&task_id).ok_or(<Error<T>>::TaskNotExist)?;
@@ -482,10 +513,14 @@ pub mod pallet {
 			ensure!(T::Time::now() < deadline_duration, Error::<T>::IncorrectDeadlineTimestamp);
 
 			// Init Task Object
-			task.title = new_title.to_vec();
-			task.specification = new_specification.to_vec();
+			task.title = new_title.clone();
+			task.specification = new_specification.clone();
 			task.budget = *new_budget;
 			task.deadline = new_deadline;
+			task.attachments = attachments.clone();
+			task.keywords = keywords.clone();
+			task.feedback = feedback.clone();
+			task.updated_at = <frame_system::Pallet<T>>::block_number();
 
 			// Insert task into Hashmap
 			<Tasks<T>>::insert(task_id, task);
@@ -552,6 +587,7 @@ pub mod pallet {
 			// Set current owner to initiator
 			task.current_owner = task.initiator.clone();
 			task.status = TaskStatus::Completed;
+			task.completed_at = <frame_system::Pallet<T>>::block_number();
 			let task_initiator = task.initiator.clone();
 
 			// Insert into update task

--- a/pallets/task/src/lib.rs
+++ b/pallets/task/src/lib.rs
@@ -51,10 +51,12 @@
 //!
 //! - `create_task` - Function used to create a new task.
 //! 	Inputs:
-//! 		- title: Vec<u8>,
-//! 		- specification: Vec<u8>,
+//! 		- title: BoundedVec,
+//! 		- specification: BoundedVec,
 //! 		- budget: BalanceOf<T>,
 //! 		- deadline: u64
+//! 		- attachments: BoundedVec,
+//! 		- keywords: BoundedVec
 //!
 //! - `update_task` - Function used to update already existing task.
 //! 	Inputs:
@@ -62,7 +64,9 @@
 //! 		- title: Vec<u8>,
 //! 		- specification: Vec<u8>,
 //! 		- budget: BalanceOf<T>,
-//! 		- deadline: u64
+//! 		- deadline: u64,
+//! 		- attachments, BoundedVec
+//! 		- keywords: BoundedVec,
 //! 	Only the creator of the task has the update rights.
 //!
 //! - `remove_task` - Function used to remove an already existing task.
@@ -85,6 +89,7 @@
 //! - `reject_task` - Function used to reject an already completed task.
 //! 	Inputs:
 //! 	- task_id: T::Hash,
+//! 	- feedback : BoundedVec
 //!
 //! ## Related Modules
 //!

--- a/pallets/task/src/mock.rs
+++ b/pallets/task/src/mock.rs
@@ -111,6 +111,16 @@ parameter_types! {
 	// One can owned at most 77 tasks
 	pub const MaxTasksOwned: u32 = 77;
 	pub TestPalletID : PalletId = PalletId(*b"task_pal");
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxTitleLen: u32 = 256;
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxSpecificationLen: u32 = 256;
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxAttachmentsLen: u32 = 5000;
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxFeedbackLen: u32 = 5000;
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxKeywordsLen: u32 = 100;
 }
 
 impl pallet_task::Config for Test {
@@ -120,6 +130,12 @@ impl pallet_task::Config for Test {
 	type Time = Time;
 	type WeightInfo = ();
 	type PalletId = TestPalletID;
+	type MaxTitleLen = MaxTitleLen;
+	type MaxSpecificationLen = MaxSpecificationLen;
+	type MaxAttachmentsLen = MaxAttachmentsLen;
+	type MaxFeedbackLen = MaxFeedbackLen;
+	type MaxKeywordsLen = MaxKeywordsLen;
+
 }
 
 pub(crate) fn new_test_ext() -> sp_io::TestExternalities {

--- a/pallets/task/src/tests.rs
+++ b/pallets/task/src/tests.rs
@@ -789,35 +789,37 @@ fn delete_task_after_deadline() {
 	});
 }
 
-// #[test]
-// fn block_time_is_added_when_task_is_updated() {
-// 	new_test_ext().execute_with( || {
-// 		System::set_block_number(1);
+#[test]
+fn block_time_is_added_when_task_is_updated() {
+	new_test_ext().execute_with( || {
+		System::set_block_number(1);
 
-// 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
+		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
-// 		// Ensure new task can be created.
-// 		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
+		// Ensure new task can be created.
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
-// 		// Get hash of task owned
-// 		let hash = Task::tasks_owned(1)[0];
-// 		let task = Task::tasks(hash).expect("should found the task");
+		// Get hash of task owned
+		let hash = Task::tasks_owned(1)[0];
+		let task = Task::tasks(hash).expect("should found the task");
 
-// 		// Ensure block time of task creation is correct
-// 		assert_eq!(task.created_at, 1);
+		// Ensure block time of task creation is correct
+		assert_eq!(task.created_at, 1);
 
-// 		System::set_block_number(3);
-// 		assert_ok!(Task::update_task(Origin::signed(1), hash, title2(), spec2(), BUDGET2, get_deadline(), attachments2(), keywords2()));
+		System::set_block_number(3);
+		assert_ok!(Task::update_task(Origin::signed(1), hash, title2(), spec2(), BUDGET2, get_deadline(), attachments2(), keywords2()));
 
-// 		assert_eq!(task.updated_at, 3);
+		let task = Task::tasks(hash).expect("should found the task");
+		assert_eq!(task.updated_at, 3);
 
-// 		// Ensure task is started by new current_owner (user 2)
-// 		assert_ok!(Task::start_task(Origin::signed(2), hash));
+		// Ensure task is started by new current_owner (user 2)
+		assert_ok!(Task::start_task(Origin::signed(2), hash));
 
-// 		System::set_block_number(100);
-// 		// Ensure task is completed by current current_owner (user 2)
-// 		assert_ok!(Task::complete_task(Origin::signed(2), hash));
-// 		assert_eq!(task.completed_at, 100);
+		System::set_block_number(100);
+		// Ensure task is completed by current current_owner (user 2)
+		assert_ok!(Task::complete_task(Origin::signed(2), hash));
+		let task = Task::tasks(hash).expect("should found the task");
+		assert_eq!(task.completed_at, 100);
 
-// 	})
-// }
+	})
+}

--- a/pallets/task/src/tests.rs
+++ b/pallets/task/src/tests.rs
@@ -57,9 +57,6 @@ fn feedback() -> BoundedVec<u8, MaxFeedbackLen> {
 	vec![1u8, 4].try_into().unwrap()
 }
 
-fn feedback2() -> BoundedVec<u8, MaxFeedbackLen> {
-	vec![1u8, 4].try_into().unwrap()
-}
 
 fn get_deadline() -> u64 {
 		// deadline is current time + 1 hour
@@ -96,7 +93,7 @@ fn create_new_task(){
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 	});
 }
 
@@ -109,7 +106,7 @@ fn fund_transfer_on_create_task(){
 
 		assert_eq!(Balances::balance(&1), 1000);
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec() , BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec() , BUDGET, get_deadline(), attachments(), keywords()));
 		assert_eq!(Balances::balance(&1), 993);
 		let task_id = Task::tasks_owned(&1)[0];
 		assert_eq!(Balances::balance(&Task::account_id(&task_id)), BUDGET);
@@ -124,7 +121,7 @@ fn increase_task_count_when_creating_task(){
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec() , BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec() , BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Assert that count is incremented by 1 after task creation
 		assert_eq!(Task::task_count(), 1);
@@ -139,8 +136,8 @@ fn increase_task_count_when_creating_two_tasks(){
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec2(), BUDGET2, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec2(), BUDGET2, get_deadline(), attachments(), keywords()));
 
 		// Assert that count is incremented to 2 after task creation
 		assert_eq!(Task::task_count(), 2);
@@ -159,14 +156,14 @@ fn cant_own_more_tax_than_max_tasks(){
 		// Create 77 tasks  ExceedMaxTasksOwned
 		for _n in 0..77 {
 			// Ensure new task can be created.
-			assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+			assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 		}
 
 		// Assert that count is incremented to 2 after task creation
 		assert_eq!(Task::task_count(), 77);
 
 		// Assert that when creating the 77 Task, Error is thrown
-		assert_noop!(Task::create_task(Origin::signed(1), title(), spec2(), BUDGET, get_deadline(), attachments(), keywords(), feedback()), Error::<Test>::ExceedMaxTasksOwned);
+		assert_noop!(Task::create_task(Origin::signed(1), title(), spec2(), BUDGET, get_deadline(), attachments(), keywords()), Error::<Test>::ExceedMaxTasksOwned);
 
 	});
 
@@ -179,7 +176,7 @@ fn assign_task_to_current_owner(){
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(10), username(), interests(), HOURS));
 
-		assert_ok!(Task::create_task(Origin::signed(10), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(10), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Get task through the hash
 		let hash = Task::tasks_owned(10)[0];
@@ -196,7 +193,7 @@ fn verify_inputs_outputs_to_tasks(){
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(10), username(), interests(), HOURS));
 
-		assert_ok!(Task::create_task(Origin::signed(10), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(10), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Get task through the hash
 		let hash = Task::tasks_owned(10)[0];
@@ -209,7 +206,6 @@ fn verify_inputs_outputs_to_tasks(){
 		assert_eq!(task.title, title());
 		assert_eq!(task.attachments, attachments());
 		assert_eq!(task.keywords, keywords());
-		assert_eq!(task.feedback, feedback());
 	});
 }
 
@@ -220,7 +216,7 @@ fn task_can_be_updated_after_it_is_created(){
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(10), username(), interests(), HOURS));
 
-		assert_ok!(Task::create_task(Origin::signed(10), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(10), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Get task through the hash
 		let hash = Task::tasks_owned(10)[0];
@@ -229,7 +225,7 @@ fn task_can_be_updated_after_it_is_created(){
 		// assert the budget is correct
 		assert_eq!(task.budget, BUDGET);
 
-		assert_ok!(Task::update_task(Origin::signed(10), hash, title2(), spec2(), BUDGET2, get_deadline(), attachments2(), keywords2(), feedback2()));
+		assert_ok!(Task::update_task(Origin::signed(10), hash, title2(), spec2(), BUDGET2, get_deadline(), attachments2(), keywords2()));
 
 		// Get task through the hash
 		let hash = Task::tasks_owned(10)[0];
@@ -241,7 +237,6 @@ fn task_can_be_updated_after_it_is_created(){
 		assert_eq!(task.title, title2());
 		assert_eq!(task.attachments, attachments2());
 		assert_eq!(task.keywords, keywords2());
-		assert_eq!(task.feedback, feedback2());
 	});
 }
 
@@ -252,13 +247,13 @@ fn task_can_be_updated_only_by_one_who_created_it(){
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(10), username(), interests(), HOURS));
 
-		assert_ok!(Task::create_task(Origin::signed(10), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(10), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Get task through the hash
 		let hash = Task::tasks_owned(10)[0];
 
 		// Throw error when someone other than creator tries to update task
-		assert_noop!(Task::update_task(Origin::signed(7), hash, title(), spec(), BUDGET2, get_deadline(), attachments2(), keywords2(), feedback2()), Error::<Test>::OnlyInitiatorUpdatesTask);
+		assert_noop!(Task::update_task(Origin::signed(7), hash, title(), spec(), BUDGET2, get_deadline(), attachments2(), keywords2()), Error::<Test>::OnlyInitiatorUpdatesTask);
 
 	});
 }
@@ -271,7 +266,7 @@ fn task_can_be_updated_only_after_it_has_been_created(){
 		assert_ok!(Profile::create_profile(Origin::signed(10), username(), interests(), HOURS));
 
 		// Ensure task can be created
-		assert_ok!(Task::create_task(Origin::signed(10), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(10), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Get task through the hash
 		let hash = Task::tasks_owned(10)[0];
@@ -280,7 +275,7 @@ fn task_can_be_updated_only_after_it_has_been_created(){
 		assert_ok!(Task::start_task(Origin::signed(2), hash));
 
 		// Throw error when someone other than creator tries to update task
-		assert_noop!(Task::update_task(Origin::signed(10), hash, title(), spec(), BUDGET2, get_deadline(), attachments2(), keywords2(), feedback2()), Error::<Test>::NoPermissionToUpdate);
+		assert_noop!(Task::update_task(Origin::signed(10), hash, title(), spec(), BUDGET2, get_deadline(), attachments2(), keywords2()), Error::<Test>::NoPermissionToUpdate);
 
 	});
 }
@@ -294,7 +289,7 @@ fn start_tasks_assigns_new_current_owner(){
 		assert_ok!(Profile::create_profile(Origin::signed(2), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Ensure new task is assigned to new current_owner (user 1)
 		let hash = Task::tasks_owned(1)[0];
@@ -320,7 +315,7 @@ fn start_tasks_assigns_task_to_volunteer(){
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Ensure new task is assigned to new current_owner (user 1)
 		let hash = Task::tasks_owned(1)[0];
@@ -346,7 +341,7 @@ fn completing_tasks_assigns_new_current_owner(){
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Ensure new task is assigned to new current_owner (user 1)
 		let hash = Task::tasks_owned(1)[0];
@@ -378,7 +373,7 @@ fn the_volunteer_is_different_from_task_creator(){
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		let hash = Task::tasks_owned(1)[0];
 		assert_noop!(Task::start_task(Origin::signed(1), hash), Error::<Test>::NoPermissionToStart);
@@ -394,7 +389,7 @@ fn task_can_only_be_started_once(){
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Ensure that task can't be started once its started
 		let hash = Task::tasks_owned(1)[0];
@@ -411,7 +406,7 @@ fn task_can_only_be_finished_by_the_user_who_started_it(){
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Ensure that task can't be started once its started
 		let hash = Task::tasks_owned(1)[0];
@@ -430,7 +425,7 @@ fn task_can_be_removed_by_owner(){
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Ensure that task can't be started once its started
 		let hash = Task::tasks_owned(1)[0];
@@ -452,7 +447,7 @@ fn task_can_be_removed_only_when_status_is_created(){
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), 7, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), 7, get_deadline(), attachments(), keywords()));
 
 		// Ensure that task can't be started once its started
 		let hash = Task::tasks_owned(1)[0];
@@ -474,7 +469,7 @@ fn only_creator_accepts_task(){
 		assert_ok!(Profile::create_profile(Origin::signed(2), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Ensure new task is assigned to new current_owner (user 1)
 		let hash = Task::tasks_owned(1)[0];
@@ -510,7 +505,7 @@ fn accepted_task_is_added_to_completed_task_for_volunteer(){
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 		assert_ok!(Profile::create_profile(Origin::signed(2), username(), interests(), HOURS));
 
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		let hash = Task::tasks_owned(1)[0];
 		assert_ok!(Task::start_task(Origin::signed(2), hash));
@@ -534,7 +529,7 @@ fn volunteer_gets_paid_on_task_completion(){
 		assert_ok!(Profile::create_profile(Origin::signed(2), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		let hash = Task::tasks_owned(1)[0];
 		// Ensure task is started by new current_owner (user 2)
@@ -562,7 +557,7 @@ fn only_started_task_can_be_completed(){
 		assert_ok!(Profile::create_profile(Origin::signed(2), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Ensure new task is assigned to new current_owner (user 1)
 		let hash = Task::tasks_owned(1)[0];
@@ -589,7 +584,7 @@ fn when_task_is_accepted_ownership_is_cleared(){
 		assert_ok!(Profile::create_profile(Origin::signed(2), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Ensure new task is assigned to new current_owner (user 1)
 		let hash = Task::tasks_owned(1)[0];
@@ -629,7 +624,7 @@ fn decrease_task_count_when_accepting_task(){
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Get hash of task owned
 		let hash = Task::tasks_owned(1)[0];
@@ -649,7 +644,7 @@ fn task_can_be_rejected_by_creator(){
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Get hash of task owned
 		let hash = Task::tasks_owned(1)[0];
@@ -666,13 +661,49 @@ fn task_can_be_rejected_by_creator(){
 		assert_ok!(Task::complete_task(Origin::signed(2), hash));
 
 		// Task is rejected by creator
-		assert_ok!(Task::reject_task(Origin::signed(1), hash));
+		assert_ok!(Task::reject_task(Origin::signed(1), hash, feedback()));
 
 		// Assert that the status is back in progress and, owner is the volunteer
 		let hash = Task::tasks_owned(2)[0];
 		let task = Task::tasks(hash).expect("should found the task");
 		assert_eq!(task.current_owner, 2);
 		assert_eq!(task.status, TaskStatus::InProgress);
+
+	});
+}
+
+
+#[test]
+fn feedback_is_given_when_task_is_rejected(){
+	new_test_ext().execute_with( || {
+
+		// Profile is necessary for task creation
+		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
+
+		// Ensure new task can be created.
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
+
+		// Get hash of task owned
+		let hash = Task::tasks_owned(1)[0];
+		let _task = Task::tasks(hash).expect("should found the task");
+
+		// Ensure task is started by new current_owner (user 2)
+		assert_ok!(Task::start_task(Origin::signed(2), hash));
+
+		// Ensure when task is started user1 has 0 tasks, and user2 has 1
+		assert_eq!(Task::tasks_owned(1).len(), 0);
+		assert_eq!(Task::tasks_owned(2).len(), 1);
+
+		// Ensure task is completed by current current_owner (user 2)
+		assert_ok!(Task::complete_task(Origin::signed(2), hash));
+
+		// Task is rejected by creator
+		assert_ok!(Task::reject_task(Origin::signed(1), hash, feedback()));
+
+		// Assert that the status is back in progress and, owner is the volunteer
+		let hash = Task::tasks_owned(2)[0];
+		let task = Task::tasks(hash).expect("should found the task");
+		assert_eq!(task.feedback, Some(feedback()));
 
 	});
 }
@@ -689,7 +720,7 @@ fn increase_profile_reputation_when_task_completed(){
 		assert_ok!(Profile::create_profile(Origin::signed(2), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Ensure new task is assigned to new current_owner (user 1)
 		let hash = Task::tasks_owned(1)[0];
@@ -723,7 +754,7 @@ fn only_add_reputation_when_task_has_been_accepted(){
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 		// Get hash of task owned
 		let hash = Task::tasks_owned(1)[0];
@@ -747,7 +778,7 @@ fn delete_task_after_deadline() {
 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 		// Ensure new task can be created.
-		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 		let hash = Task::tasks_owned(1)[0];
 		let task = Task::tasks(hash);
 		assert!(task.is_some());
@@ -766,7 +797,7 @@ fn delete_task_after_deadline() {
 // 		assert_ok!(Profile::create_profile(Origin::signed(1), username(), interests(), HOURS));
 
 // 		// Ensure new task can be created.
-// 		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords(), feedback()));
+// 		assert_ok!(Task::create_task(Origin::signed(1), title(), spec(), BUDGET, get_deadline(), attachments(), keywords()));
 
 // 		// Get hash of task owned
 // 		let hash = Task::tasks_owned(1)[0];
@@ -776,7 +807,7 @@ fn delete_task_after_deadline() {
 // 		assert_eq!(task.created_at, 1);
 
 // 		System::set_block_number(3);
-// 		assert_ok!(Task::update_task(Origin::signed(1), hash, title2(), spec2(), BUDGET2, get_deadline(), attachments2(), keywords2(), feedback2()));
+// 		assert_ok!(Task::update_task(Origin::signed(1), hash, title2(), spec2(), BUDGET2, get_deadline(), attachments2(), keywords2()));
 
 // 		assert_eq!(task.updated_at, 3);
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -278,6 +278,16 @@ parameter_types! {
 	// Max tasks per user.
 	pub const MaxTasksOwned: u32 = 77;
 	pub TaskPalletID: PalletId = PalletId(*b"task_pal");
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxTitleLen: u32 = 256;
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxSpecificationLen: u32 = 256;
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxAttachmentsLen: u32 = 5000;
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxFeedbackLen: u32 = 5000;
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxKeywordsLen: u32 = 100;
 }
 
 // Configure the pallet-task.
@@ -288,6 +298,11 @@ impl pallet_task::Config for Runtime {
 	type Time = Timestamp;
 	type WeightInfo = pallet_task::weights::SubstrateWeight<Runtime>;
 	type PalletId = TaskPalletID;
+	type MaxTitleLen = MaxTitleLen;
+	type MaxSpecificationLen = MaxSpecificationLen;
+	type MaxAttachmentsLen = MaxAttachmentsLen;
+	type MaxFeedbackLen = MaxFeedbackLen;
+	type MaxKeywordsLen = MaxKeywordsLen;
 }
 
 // Configure the pallet-dao.


### PR DESCRIPTION
Review for task: https://github.com/UniversalDot/universal-dot-node/issues/43

There is a commented-out test. For some reason, `updated_at` and `completed_at` block time is not added to task properties and it is always 0. For `created_at` it works. Do you know why?

I cleaned up the task tests a little. We should do something similar for other tests and benchmarks. 

Budget: $15

