### PR TITLE
83 process clippy warnings

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+too-many-arguments-threshold = 10
+type-complexity-threshold = 350

--- a/pallets/dao/src/benchmarking.rs
+++ b/pallets/dao/src/benchmarking.rs
@@ -101,7 +101,7 @@ benchmarks! {
 	verify {
 		// let hash = PalletDao::<T>::get_hash_for_dao(&caller, &name, &description, &vision, 1_u32.into(), 1_u32.into());
 		let hash = PalletDao::<T>::member_of(&caller)[0];
-		assert_last_event::<T>(Event::<T>::OrganizationCreated(caller, hash.into()).into())
+		assert_last_event::<T>(Event::<T>::OrganizationCreated(caller, hash).into())
 	}
 
 	update_organization {
@@ -132,7 +132,7 @@ benchmarks! {
 	}: update_organization(RawOrigin::Signed(caller.clone()), org_id, Some(name), Some(description), Some(vision))
 	verify {
 		let hash = PalletDao::<T>::member_of(&caller)[0];
-		assert_last_event::<T>(Event::<T>::OrganizationUpdated(caller, hash.into()).into())
+		assert_last_event::<T>(Event::<T>::OrganizationUpdated(caller, hash).into())
 	}
 
 	transfer_ownership {
@@ -150,7 +150,7 @@ benchmarks! {
 	}: transfer_ownership(RawOrigin::Signed(caller.clone()), org_id, caller.clone())
 	verify {
 		let hash = PalletDao::<T>::member_of(&caller)[0];
-		assert_last_event::<T>(Event::<T>::OrganizationOwnerChanged(caller.clone(), hash.into(), caller).into())
+		assert_last_event::<T>(Event::<T>::OrganizationOwnerChanged(caller.clone(), hash, caller).into())
 	}
 
 	dissolve_organization {
@@ -167,7 +167,7 @@ benchmarks! {
 		// let org_id = PalletDao::<T>::get_hash_for_dao(&caller, &name, &description, &vision, 0_u32.into(), 0_u32.into());
 		let org_id = PalletDao::<T>::member_of(&caller)[0];
 
-	}: dissolve_organization(RawOrigin::Signed(caller.clone()), org_id.clone())
+	}: dissolve_organization(RawOrigin::Signed(caller.clone()), org_id)
 		/* the code to be benchmarked */
 
 	verify {
@@ -192,7 +192,7 @@ benchmarks! {
 		// let org_id = PalletDao::<T>::get_hash_for_dao(&caller, &name, &description, &vision, 0_u32.into(), 0_u32.into());
 		let org_id = PalletDao::<T>::member_of(&caller)[0];
 
-	}: add_members(RawOrigin::Signed(caller.clone()), org_id.clone(), account.clone())
+	}: add_members(RawOrigin::Signed(caller.clone()), org_id, account.clone())
 		/* the code to be benchmarked */
 	verify {
 		/* verifying final state */
@@ -216,14 +216,14 @@ benchmarks! {
 		let _ = PalletDao::<T>::create_organization(RawOrigin::Signed(caller.clone()).into(), name, description, vision);
 		// let org_id = PalletDao::<T>::get_hash_for_dao(&caller, &name, &description, &vision, 0_u32.into(), 0_u32.into());
 		let org_id = PalletDao::<T>::member_of(&caller)[0];
-		let _ = PalletDao::<T>::add_members(RawOrigin::Signed(caller.clone()).into(), org_id.clone(), account.clone());
-		assert_eq!(PalletDao::<T>::members(org_id.clone()).len(), 2);
+		let _ = PalletDao::<T>::add_members(RawOrigin::Signed(caller.clone()).into(), org_id, account.clone());
+		assert_eq!(PalletDao::<T>::members(org_id).len(), 2);
 
-	}: remove_members(RawOrigin::Signed(caller.clone()), org_id.clone(), account.clone() )
+	}: remove_members(RawOrigin::Signed(caller.clone()), org_id, account.clone() )
 		/* the code to be benchmarked */
 	verify {
 		/* verifying final state */
-		assert_eq!(PalletDao::<T>::members(org_id.clone()).len(), 1);
+		assert_eq!(PalletDao::<T>::members(org_id).len(), 1);
 		assert_last_event::<T>(Event::<T>::MemberRemoved (caller, account, org_id).into());
 	}
 }

--- a/pallets/did/src/benchmarking.rs
+++ b/pallets/did/src/benchmarking.rs
@@ -22,37 +22,37 @@ benchmarks! {
     add_delegate {
         let caller = make_caller!(T);
         let delegate:T::AccountId = account("delegate", 0, 0);
-    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), delegate.clone(), Vec::new(), Some(T::BlockNumber::one()))
+    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), delegate, Vec::new(), Some(T::BlockNumber::one()))
 
     change_owner {
         let caller = make_caller!(T);
         let new_owner:T::AccountId = account("new_owner", 0, 0);
 
-    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), new_owner.clone())
+    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), new_owner)
 
     revoke_delegate {
         let caller = make_caller!(T);
         let delegate:T::AccountId = account("delegate", 0, 0);
         let _ = Did::<T>::add_delegate(RawOrigin::Signed(caller.clone()).into(), caller.clone(), delegate.clone(), Vec::new(), None);
-    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), Vec::new(), delegate.clone())
+    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), Vec::new(), delegate)
 
     add_attribute {
         let caller = make_caller!(T);
         let name = b"name1".to_vec();
         let value = b"value1".to_vec();
-    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), name.clone(), value.clone(), Some(T::BlockNumber::one()))
+    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), name, value, Some(T::BlockNumber::one()))
 
     revoke_attribute {
         let caller = make_caller!(T);
         let name = b"name1".to_vec();
         let value = b"value1".to_vec();
-        let _ = Did::<T>::add_attribute(RawOrigin::Signed(caller.clone()).into(), caller.clone(), name.clone(), value.clone(), None);
-    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), name.clone())
+        let _ = Did::<T>::add_attribute(RawOrigin::Signed(caller.clone()).into(), caller.clone(), name.clone(), value, None);
+    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), name)
 
     delete_attribute {
         let caller = make_caller!(T);
         let name = b"name1".to_vec();
         let value = b"value1".to_vec();
-        let _ = Did::<T>::add_attribute(RawOrigin::Signed(caller.clone()).into(), caller.clone(), name.clone(), value.clone(), None);
-    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), name.clone())
+        let _ = Did::<T>::add_attribute(RawOrigin::Signed(caller.clone()).into(), caller.clone(), name.clone(), value, None);
+    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), name)
 }

--- a/pallets/grant/src/benchmarking.rs
+++ b/pallets/grant/src/benchmarking.rs
@@ -21,12 +21,8 @@ use super::*;
 
 #[allow(unused)]
 use crate::Pallet as PalletGrant;
-use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_caller, vec};
+use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_caller};
 use frame_system::RawOrigin;
-use sp_std::convert::TryInto;
-
-use frame_support::{
-	traits::{Currency}};
 
 // Helper function to assert event thrown during verification
 fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {

--- a/pallets/grant/src/lib.rs
+++ b/pallets/grant/src/lib.rs
@@ -15,7 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 //! # Grant Pallet
 //! 
 //! ## Version: 0.0.1
@@ -34,29 +33,26 @@
 //! The intention is that initially, when there are only few users of the platform, every grant_request is
 //! automatically approved. However, later on when the application reaches more use, grants are offered randomly
 //! to requesting accounts. 
-//! 	
+//!
 //! The Process is envisioned as follows:
 //! 1. Anyone can send Funds into a Treasury Account. The Treasury account is used to distribute grant rewards.
-//! 2. Anyone can request a grant each block.	
+//! 2. Anyone can request a grant each block.
 //! 3. Each block a grant is offered randomly to selected grant requester.
-//! 
-//! 
-//! 	
+//!
 //! ## Interface
 //!
 //! ### Public Functions
 //!  -  request_grant()
-//!		Function used to request grants.
+//!     Function used to request grants.
 //!
 //!  -  transfer_funds()
-//!		Function used to transfer funds into a Treasury Account. Anyone can transfer into Treasury.
+//!     Function used to transfer funds into a Treasury Account. Anyone can transfer into Treasury.
 //!
 //!  -  winner_is()
-//!		Function that announces the winner of the block.
+//!     Function that announces the winner of the block.
 //!
 //! ## Related Modules
 //!
-
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -341,15 +337,5 @@ pub mod pallet {
 
 			Ok(())
 		}
-
-		// Function that check if user has made requests
-		fn has_made_requests(owner: &T::AccountId) -> Result<bool, DispatchError>  {
-
-			// Check if an account has a profile
-			Self::storage_requesters(owner).ok_or(<Error<T>>::RequestAlreadyMade)?;
-
-			Ok(true)
-		}
 	}
-
 }

--- a/pallets/grant/src/tests.rs
+++ b/pallets/grant/src/tests.rs
@@ -206,7 +206,7 @@ fn winner_can_be_recieve_grant_reward() {
 		// Add balance to grant treasury account
 		Balances::mutate_account(&Grant::account_id(), |balance| {
 			balance.free = 100;
-		});
+		}).expect("could not set treasury account balance");
 		let treasury = Balances::free_balance(Grant::account_id());
 		assert_eq!(treasury, 100);
 		

--- a/pallets/profile/src/benchmarking.rs
+++ b/pallets/profile/src/benchmarking.rs
@@ -37,7 +37,7 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 // This creates an `Profile` object.
 fn create_profile_info<T: Config>(_num_fields: u32) -> Profile<T> {
 
-	let s: u8 = u8::MAX.into();
+	let s: u8 = u8::MAX;
 	let interests = vec![0u8, s as u8];
 	let username = vec![0u8, s as u8];
 	let available_hours_per_week = 40_u8;
@@ -45,7 +45,7 @@ fn create_profile_info<T: Config>(_num_fields: u32) -> Profile<T> {
 	let caller: T::AccountId = whitelisted_caller();
 	let balance = T::Currency::free_balance(&caller);
 
-	let info = Profile {
+	Profile {
 		owner: caller,
 		name: username.try_into().unwrap(),
 		interests: interests.try_into().unwrap(),
@@ -53,9 +53,7 @@ fn create_profile_info<T: Config>(_num_fields: u32) -> Profile<T> {
 		reputation: u32::MAX,
 		available_hours_per_week,
 		additional_information: None,
-	};
-
-	return info
+	}
 }
 
 

--- a/pallets/profile/src/lib.rs
+++ b/pallets/profile/src/lib.rs
@@ -34,31 +34,30 @@
 //! ### Public Functions
 //!
 //! - `create_profile` - Function used to create a new user profile.
-//! 	Requirements: 
-//! 	1. Each account can create a single Profile.
-//! 	2. Profiles are mandatory for creating Tasks.
-//! 	Inputs: 
-//! 		- username: BoundedVec,
-//! 		- interests: BoundedVec,
-//! 		- available_hours_per_week: u8,
-//! 		- additional_information
+//!     Requirements:
+//!     1. Each account can create a single Profile.
+//!     2. Profiles are mandatory for creating Tasks.
+//!     Inputs:
+//!         - username: BoundedVec,
+//!         - interests: BoundedVec,
+//!         - available_hours_per_week: u8,
+//!         - additional_information
 //!
 //! - `update_profile` - Function used to update an already existing user profile.
-//! 	Inputs: 
-//! 		- username: BoundedVec,
-//! 		- interests: BoundedVec,
-//! 		- available_hours_per_week: u8,
-//! 		- additional_information
+//!     Inputs:
+//!         - username: BoundedVec,
+//!         - interests: BoundedVec,
+//!         - available_hours_per_week: u8,
+//!         - additional_information
 //!
 //! - `remove_profile` - Function used to delete an existing user profile.
-//! 	Inputs: 
-//! 		No Inputs
+//!     Inputs:
+//!         No Inputs
 //!
 //! Storage Items:
-//! 	Profiles: Stores profile Information
-//! 	ProfileCount: Counts the total number of Profiles
-//! 	CompletedTasks: Stores the completed Tasks history for a Profile
-//! 	
+//!     Profiles: Stores profile Information
+//!     ProfileCount: Counts the total number of Profiles
+//!     CompletedTasks: Stores the completed Tasks history for a Profile
 //!
 //! ## Related Modules
 //!

--- a/pallets/profile/src/tests.rs
+++ b/pallets/profile/src/tests.rs
@@ -44,7 +44,7 @@ fn create_profile_works() {
 
 #[test]
 fn verify_inputs_outputs_to_profile(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 
 		// Create Profile
 		assert_ok!(Profile::create_profile(Origin::signed(10), username(), interests(), HOURS, Some(additional_info())));

--- a/pallets/task/src/benchmarking.rs
+++ b/pallets/task/src/benchmarking.rs
@@ -189,7 +189,7 @@ benchmarks! {
 		create_profile::<T>();
 		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(task_creator.clone()).into(), title.try_into().unwrap(), specification.try_into().unwrap(), budget, x.into(), attachments.try_into().unwrap(), keywords.try_into().unwrap(), Some(organization));
 		let hash_task = PalletTask::<T>::tasks_owned(&task_creator)[0];
-		let _ = PalletTask::<T>::start_task(RawOrigin::Signed(volunteer.clone()).into(), hash_task.clone());
+		let _ = PalletTask::<T>::start_task(RawOrigin::Signed(volunteer.clone()).into(), hash_task);
 
 	}: complete_task(RawOrigin::Signed(volunteer.clone()), hash_task)
 		/* the code to be benchmarked */
@@ -218,8 +218,8 @@ benchmarks! {
 		create_profile::<T>();
 		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(task_creator.clone()).into(), title.try_into().unwrap(), specification.try_into().unwrap(), budget, x.into(), attachments.try_into().unwrap(), keywords.try_into().unwrap(), Some(organization));
 		let hash_task = PalletTask::<T>::tasks_owned(&task_creator)[0];
-		let _ = PalletTask::<T>::start_task(RawOrigin::Signed(volunteer.clone()).into(), hash_task.clone());
-		let _ = PalletTask::<T>::complete_task(RawOrigin::Signed(volunteer.clone()).into(), hash_task.clone());
+		let _ = PalletTask::<T>::start_task(RawOrigin::Signed(volunteer.clone()).into(), hash_task);
+		let _ = PalletTask::<T>::complete_task(RawOrigin::Signed(volunteer).into(), hash_task);
 
 	}: accept_task(RawOrigin::Signed(task_creator.clone()), hash_task)
 		/* the code to be benchmarked */
@@ -250,8 +250,8 @@ benchmarks! {
 		create_profile::<T>();
 		let _ = PalletTask::<T>::create_task(RawOrigin::Signed(task_creator.clone()).into(), title.try_into().unwrap(), specification.try_into().unwrap(), budget, x.into(), attachments.try_into().unwrap(), keywords.try_into().unwrap(), Some(organization));
 		let hash_task = PalletTask::<T>::tasks_owned(&task_creator)[0];
-		let _ = PalletTask::<T>::start_task(RawOrigin::Signed(volunteer.clone()).into(), hash_task.clone());
-		let _ = PalletTask::<T>::complete_task(RawOrigin::Signed(volunteer.clone()).into(), hash_task.clone());
+		let _ = PalletTask::<T>::start_task(RawOrigin::Signed(volunteer.clone()).into(), hash_task);
+		let _ = PalletTask::<T>::complete_task(RawOrigin::Signed(volunteer).into(), hash_task);
 
 	}: reject_task(RawOrigin::Signed(task_creator.clone()), hash_task, feedback.try_into().unwrap())
 		/* the code to be benchmarked */

--- a/pallets/task/src/lib.rs
+++ b/pallets/task/src/lib.rs
@@ -46,54 +46,54 @@
 //! ### Public Functions
 //!
 //! - `create_task` - Function used to create a new task.
-//! 	Inputs:
-//! 		- title: BoundedVec,
-//! 		- specification: BoundedVec,
-//! 		- budget: BalanceOf<T>,
-//! 		- deadline: u64
-//! 		- attachments: BoundedVec,
-//! 		- keywords: BoundedVec
-//! 		- organization: Option<OrganizationIdOf<T>>
+//!     Inputs:
+//!         - title: BoundedVec,
+//!         - specification: BoundedVec,
+//!         - budget: BalanceOf<T>,
+//!         - deadline: u64
+//!         - attachments: BoundedVec,
+//!         - keywords: BoundedVec
+//!         - organization: Option<OrganizationIdOf<T>>
 //!
 //! - `update_task` - Function used to update already existing task.
-//! 	Inputs:
-//! 		- task_id: T::Hash,
-//! 		- title: Vec<u8>,
-//! 		- specification: Vec<u8>,
-//! 		- budget: BalanceOf<T>,
-//! 		- deadline: u64,
-//! 		- attachments, BoundedVec
-//! 		- keywords: BoundedVec,
-//! 		- organization: Option<OrganizationIdOf<T>>
-//! 	Only the creator of the task has the update rights.
+//!     Inputs:
+//!         - task_id: T::Hash,
+//!         - title: Vec<u8>,
+//!         - specification: Vec<u8>,
+//!         - budget: BalanceOf<T>,
+//!         - deadline: u64,
+//!         - attachments, BoundedVec
+//!         - keywords: BoundedVec,
+//!         - organization: Option<OrganizationIdOf<T>>
+//!     Only the creator of the task has the update rights.
 //!
 //! - `remove_task` - Function used to remove an already existing task.
-//! 	Inputs:
-//! 		- task_id: T::Hash,
+//!     Inputs:
+//!         - task_id: T::Hash,
 //!
 //! - `start_task` - Function used to start already existing task.
-//! 	Inputs:
-//! 		- task_id: T::Hash,
+//!     Inputs:
+//!         - task_id: T::Hash,
 //!
 //! - `complete_task` - Function used to complete a task.
-//! 	Inputs:
-//! 		- task_id: T::Hash,
+//!     Inputs:
+//!         - task_id: T::Hash,
 //!
 //! - `accept_task` - Function used to accept completed task.
-//! 	Inputs:
-//! 		- task_id: T::Hash,
-//! 	After the task is accepted, its data is removed from storage.
+//!     Inputs:
+//!         - task_id: T::Hash,
+//!     After the task is accepted, its data is removed from storage.
 //!
 //! - `reject_task` - Function used to reject an already completed task.
-//! 	Inputs:
-//! 	- task_id: T::Hash,
-//! 	- feedback : BoundedVec
+//!     Inputs:
+//!     - task_id: T::Hash,
+//!     - feedback : BoundedVec
 //! 
 //! Storage Items:
-//! 	Tasks: Stores Task related information
-//! 	TaskCount: Counts the total number of Tasks in the ecosystem
-//! 	TasksOwned: Keeps track of how many tasks are owned per account
-//! 
+//!     Tasks: Stores Task related information
+//!     TaskCount: Counts the total number of Tasks in the ecosystem
+//!     TasksOwned: Keeps track of how many tasks are owned per account
+//!
 //!
 //! ## Related Modules
 //!
@@ -162,7 +162,7 @@ pub mod pallet {
 	}
 
 	// Set TaskStatus enum.
-	#[derive(Clone, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 	#[scale_info(skip_type_params(T))]
   	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
   	pub enum TaskStatus {
@@ -314,7 +314,7 @@ pub mod pallet {
 			// need existential deposit check?
 			ensure!(<T as self::Config>::Currency::can_reserve(&signer, budget), Error::<T>::NotEnoughBalance);
 			// Reserve currency of the task creator.
-			<T as self::Config>::Currency::reserve(&signer, budget.into()).expect("can_reserve has been called; qed");
+			<T as self::Config>::Currency::reserve(&signer, budget).expect("can_reserve has been called; qed");
 
 			// Emit a Task Created Event.
 			Self::deposit_event(Event::TaskCreated(signer, task_id));
@@ -368,7 +368,7 @@ pub mod pallet {
 			}
 
 			// Update storage after as we need to check if sender can reserve new amount.
-			let _task_id = Self::update_created_task(old_task, &task_id, title, specification, &budget, deadline, attachments, keywords, organization)?;
+			Self::update_created_task(old_task, &task_id, title, specification, &budget, deadline, attachments, keywords, organization)?;
 
 			// Emit a Task Updated Event.
 			Self::deposit_event(Event::TaskUpdated(signer, task_id));
@@ -437,7 +437,7 @@ pub mod pallet {
 			let mut task = Self::tasks(&task_id).ok_or(<Error<T>>::TaskNotExist)?;
 
 			// Ensure owner
-			ensure!(&task.current_owner == &signer, Error::<T>::OnlyInitiatorAcceptsTask);
+			ensure!(task.current_owner == signer, Error::<T>::OnlyInitiatorAcceptsTask);
 
 			// Transfer reserved funds of task amount to volunteer.
 			<T as self::Config>::Currency::unreserve(&signer, task.budget);
@@ -518,7 +518,7 @@ pub mod pallet {
 				attachments,
 				keywords,
 				feedback: None, // Only used when task is rejected
-				organization: organization,
+				organization,
 				created_at: <frame_system::Pallet<T>>::block_number(),
 				updated_at: Default::default(),
 				completed_at: Default::default(),
@@ -549,12 +549,12 @@ pub mod pallet {
 
 			let mut new_task: Task<T> = old_task;
 			// Init Task Object
-			new_task.title = new_title.clone();
-			new_task.specification = new_specification.clone();
+			new_task.title = new_title;
+			new_task.specification = new_specification;
 			new_task.budget = *new_budget;
 			new_task.deadline = new_deadline;
-			new_task.attachments = attachments.clone();
-			new_task.keywords = keywords.clone();
+			new_task.attachments = attachments;
+			new_task.keywords = keywords;
 			new_task.organization = organization;
 			new_task.updated_at = <frame_system::Pallet<T>>::block_number();
 
@@ -689,7 +689,7 @@ pub mod pallet {
 			// Set current owner back to volunteer
 			task.current_owner = task.volunteer.clone();
 			task.status = TaskStatus::InProgress;
-			task.feedback = Some(feedback.clone());
+			task.feedback = Some(feedback);
 			let task_volunteer = task.volunteer.clone();
 
 			// Insert task
@@ -718,7 +718,7 @@ pub mod pallet {
 			<Tasks<T>>::remove(task_id);
 
 			// Unreserve balance amount from task creator
-			<T as self::Config>::Currency::unreserve(&task_initiator, task.budget);
+			<T as self::Config>::Currency::unreserve(task_initiator, task.budget);
 
 			// Reduce task count
 			let new_count = Self::task_count().saturating_sub(1);
@@ -738,6 +738,7 @@ pub mod pallet {
 		// Function that generates escrow account based on TaskID
 		// todo: ensure that usage of into_account_truncating is correct
 		// See: https://paritytech.github.io/substrate/master/sp_runtime/traits/trait.AccountIdConversion.html#tymethod.into_sub_account_truncating
+		#[allow(dead_code)] // Used in test only
 		pub(crate) fn account_id(task_id: &T::Hash) -> T::AccountId {
 			T::PalletId::get().into_sub_account_truncating(task_id)
 		}

--- a/pallets/task/src/tests.rs
+++ b/pallets/task/src/tests.rs
@@ -138,7 +138,7 @@ fn create_new_task(){
 
 #[test]
 fn fund_transfer_on_create_task(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -155,7 +155,7 @@ fn fund_transfer_on_create_task(){
 
 #[test]
 fn increase_task_count_when_creating_task(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -169,7 +169,7 @@ fn increase_task_count_when_creating_task(){
 
 #[test]
 fn increase_task_count_when_creating_two_tasks(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -184,7 +184,7 @@ fn increase_task_count_when_creating_two_tasks(){
 
 #[test]
 fn cant_own_more_tasks_than_max_tasks(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -204,7 +204,7 @@ fn cant_own_more_tasks_than_max_tasks(){
 
 #[test]
 fn assign_task_to_current_owner(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*TED), username(), interests(), HOURS, Some(additional_info())));
 
@@ -222,7 +222,7 @@ fn assign_task_to_current_owner(){
 
 #[test]
 fn verify_inputs_outputs_to_tasks(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*TED), username(), interests(), HOURS, Some(additional_info())));
 
@@ -247,7 +247,7 @@ fn verify_inputs_outputs_to_tasks(){
 
 #[test]
 fn task_can_be_updated_after_it_is_created(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*TED), username(), interests(), HOURS, Some(additional_info())));
 
@@ -282,7 +282,7 @@ fn task_can_be_updated_after_it_is_created(){
 
 #[test]
 fn check_balance_after_update_task(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Get initial balance of account
 		let initial_balance_of_sender = Balances::free_balance(&*TED);
 
@@ -311,7 +311,7 @@ fn check_balance_after_update_task(){
 
 #[test]
 fn check_balance_after_complete_task(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Create profiles
 		assert_ok!(Profile::create_profile(Origin::signed(*TED), username(), interests(), HOURS, Some(additional_info())));
 		assert_ok!(Profile::create_profile(Origin::signed(*BOB), username(), interests(), HOURS, Some(additional_info())));
@@ -343,7 +343,7 @@ fn check_balance_after_complete_task(){
 
 #[test]
 fn task_can_be_updated_only_by_one_who_created_it(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*TED), username(), interests(), HOURS, Some(additional_info())));
@@ -361,7 +361,7 @@ fn task_can_be_updated_only_by_one_who_created_it(){
 
 #[test]
 fn task_can_be_updated_only_after_it_has_been_created(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*TED), username(), interests(), HOURS, Some(additional_info())));
 
@@ -381,7 +381,7 @@ fn task_can_be_updated_only_after_it_has_been_created(){
 
 #[test]
 fn start_tasks_assigns_new_current_owner(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 		assert_ok!(Profile::create_profile(Origin::signed(*BOB), username(), interests(), HOURS, Some(additional_info())));
@@ -406,7 +406,7 @@ fn start_tasks_assigns_new_current_owner(){
 
 #[test]
 fn start_tasks_assigns_task_to_volunteer(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -431,7 +431,7 @@ fn start_tasks_assigns_task_to_volunteer(){
 
 #[test]
 fn completing_tasks_assigns_new_current_owner(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -463,7 +463,7 @@ fn completing_tasks_assigns_new_current_owner(){
 
 #[test]
 fn the_volunteer_is_different_from_task_creator(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Ensure profile can be created
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -478,7 +478,7 @@ fn the_volunteer_is_different_from_task_creator(){
 
 #[test]
 fn task_can_only_be_started_once(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Ensure profile can be created
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -494,7 +494,7 @@ fn task_can_only_be_started_once(){
 
 #[test]
 fn task_can_only_be_finished_by_the_user_who_started_it(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Ensure profile can be created
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -512,7 +512,7 @@ fn task_can_only_be_finished_by_the_user_who_started_it(){
 
 #[test]
 fn task_can_be_removed_by_owner(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Ensure profile can be created
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -533,7 +533,7 @@ fn task_can_be_removed_by_owner(){
 
 #[test]
 fn task_can_be_removed_only_when_status_is_created(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Ensure profile can be created
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -551,7 +551,7 @@ fn task_can_be_removed_only_when_status_is_created(){
 
 #[test]
 fn only_creator_accepts_task(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 		assert_ok!(Profile::create_profile(Origin::signed(*BOB), username(), interests(), HOURS, Some(additional_info())));
@@ -587,7 +587,7 @@ fn only_creator_accepts_task(){
 
 #[test]
 fn accepted_task_is_added_to_completed_task_for_volunteer(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 		assert_ok!(Profile::create_profile(Origin::signed(*BOB), username(), interests(), HOURS, Some(additional_info())));
@@ -610,7 +610,7 @@ fn accepted_task_is_added_to_completed_task_for_volunteer(){
 
 #[test]
 fn volunteer_gets_paid_on_task_completion(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 		assert_ok!(Profile::create_profile(Origin::signed(*BOB), username(), interests(), HOURS, Some(additional_info())));
@@ -634,7 +634,7 @@ fn volunteer_gets_paid_on_task_completion(){
 
 #[test]
 fn only_started_task_can_be_completed(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 		assert_ok!(Profile::create_profile(Origin::signed(*BOB), username(), interests(), HOURS, Some(additional_info())));
@@ -661,7 +661,7 @@ fn only_started_task_can_be_completed(){
 
 #[test]
 fn when_task_is_accepted_ownership_is_cleared(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 		assert_ok!(Profile::create_profile(Origin::signed(*BOB), username(), interests(), HOURS, Some(additional_info())));
@@ -700,7 +700,7 @@ fn when_task_is_accepted_ownership_is_cleared(){
 
 #[test]
 fn decrease_task_count_when_accepting_task(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -719,7 +719,7 @@ fn decrease_task_count_when_accepting_task(){
 
 #[test]
 fn task_can_be_rejected_by_creator(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -753,7 +753,7 @@ fn task_can_be_rejected_by_creator(){
 
 #[test]
 fn feedback_is_given_when_task_is_rejected(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -786,7 +786,7 @@ fn feedback_is_given_when_task_is_rejected(){
 
 #[test]
 fn increase_profile_reputation_when_task_completed(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profiles necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 		assert_ok!(Profile::create_profile(Origin::signed(*BOB), username(), interests(), HOURS, Some(additional_info())));
@@ -820,7 +820,7 @@ fn increase_profile_reputation_when_task_completed(){
 
 #[test]
 fn only_add_reputation_when_task_has_been_accepted(){
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Profile is necessary for task creation
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -842,7 +842,7 @@ fn only_add_reputation_when_task_has_been_accepted(){
 
 #[test]
 fn delete_task_after_deadline() {
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		run_to_block(1);
 
 		// Profile is necessary for task creation
@@ -867,7 +867,7 @@ fn delete_task_after_deadline() {
 
 #[test]
 fn balance_check_after_task_deletion() {
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Create profile
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 		let signer_balance = Balances::balance(&*ALICE);
@@ -897,7 +897,7 @@ fn balance_check_after_task_deletion() {
 
 #[test]
 fn block_time_is_added_when_task_is_updated() {
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		System::set_block_number(1);
 
 		// Ensure profile is created before task creation
@@ -932,7 +932,7 @@ fn block_time_is_added_when_task_is_updated() {
 
 #[test]
 fn test_multiple_tasks_and_reserve_amounts() {
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Create profile (required by task)
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 
@@ -955,7 +955,7 @@ fn test_multiple_tasks_and_reserve_amounts() {
 
 #[test]
 fn test_create_insufficient_funds_to_reserve() {
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Create profile (required by task)
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 		
@@ -968,7 +968,7 @@ fn test_create_insufficient_funds_to_reserve() {
 
 #[test]
 fn test_update_insufficient_funds_to_reserve() {
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Create profile (required by task)
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 		
@@ -986,7 +986,7 @@ fn test_update_insufficient_funds_to_reserve() {
 
 #[test]
 fn test_create_two_tasks_insufficient_balance() {
-	new_test_ext().execute_with( || {
+	new_test_ext().execute_with(|| {
 		// Create profile (required by task)
 		assert_ok!(Profile::create_profile(Origin::signed(*ALICE), username(), interests(), HOURS, Some(additional_info())));
 

--- a/pallets/task/src/traits.rs
+++ b/pallets/task/src/traits.rs
@@ -1,4 +1,4 @@
 pub trait Organization<OrganizationId> {
-    /// Determines whether an organization with the supplied identifier exists.
-    fn exists(id: &OrganizationId) -> bool;
+	/// Determines whether an organization with the supplied identifier exists.
+	fn exists(id: &OrganizationId) -> bool;
 }


### PR DESCRIPTION
Resolves clippy warnings based on suggested fixes for all pallets.

A Clippy config file needed to be added to tweak the default settings to allow:
- functions with many arguments
- complex type defintions

These suggested fixes could be tackled in the future as a separate issue, but I didnt want to change too much with this PR.