### PR TITLE
91 cicd docker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish Docker Image
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push (only for the develop branch)
+  push:
+    branches: [ universal-develop ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  publish:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: universaldot/node:develop

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# Setup base layer
+FROM --platform=$BUILDPLATFORM rustlang/rust:nightly as base
+RUN rustup target add wasm32-unknown-unknown; \
+    apt-get update -y; \
+    apt-get install -y cmake pkg-config libssl-dev git gcc build-essential clang libclang-dev; \
+    cargo install cargo-chef # Use cargo-chef to simplify dependency caching
+
+# Initialise environment variable based on target architecture (maps from buildkit to Rust convention)
+FROM base AS base-amd64
+ENV ARCH=x86_64
+FROM base AS base-arm64
+ENV ARCH=aarch64
+
+# Create recipe based on all available cargo.lock and cargo.toml manifests in project - used to cache dependencies
+FROM base AS planner
+WORKDIR node
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Build
+FROM base-${TARGETARCH} AS builder
+# Configure based on target architecture
+ARG TARGETARCH
+ENV TARGET=${ARCH}-unknown-linux-gnu RUSTFLAGS="-C linker=${ARCH}-linux-gnu-gcc"
+RUN rustup target add ${ARCH}-unknown-linux-gnu; \
+    apt-get install -y gcc-${ARCH}-linux-gnu g++-${ARCH}-linux-gnu libc6-dev-${TARGETARCH}-cross; \
+    # Add missing symlinks
+    ln -s /usr/${ARCH}-linux-gnu/include/bits /usr/include/bits; \
+    ln -s /usr/${ARCH}-linux-gnu/include/sys /usr/include/sys; \
+    ln -s /usr/${ARCH}-linux-gnu/include/gnu /usr/include/gnu
+# Build dependencies using recipe created in previous stage - this is the caching Docker layer!
+WORKDIR node
+COPY --from=planner /node/recipe.json recipe.json
+RUN cargo chef cook --release --target $TARGET --recipe-path recipe.json
+# Build application
+COPY . .
+RUN cargo build --release --target $TARGET
+
+# Construct runtime
+FROM debian:stable-slim as runtime
+ENV ENVIRONMENT=dev WEBSOCKET=ws-external
+COPY --from=builder /node/target/*/release/node-template /usr/local/bin/node
+CMD /usr/local/bin/node --$ENVIRONMENT --$WEBSOCKET
+EXPOSE 9944
+
+# Finally set metadata
+LABEL org.opencontainers.image.vendor="UniversalDot" \
+    org.opencontainers.image.url="https://github.com/universaldot/universal-dot-node" \
+    org.opencontainers.image.title="UniversalDot Node" \
+    org.opencontainers.image.description="A blockchain for creating digital economies." \
+    org.opencontainers.image.documentation="https://github.com/universaldot/universal-dot-node"

--- a/README.md
+++ b/README.md
@@ -233,6 +233,21 @@ docker pull universaldot/node
 ```
 
 Furthermore, we provide a [Docker-Compose](https://github.com/UniversalDot/compose-service) service that is able to start a blockchain with basic front-end application. 
+
+#### Development
+A `develop` image is also available, which is automatically updated on each push to the `develop` branch.
+To pull/update the image locally, run the following command in your terminal.
+
+    docker pull universaldot/node:develop
+
+To run the image interactively, exposing the port and removing the container on exit:
+
+    docker run -it --rm -p 9944:9944 universaldot/node:develop
+
+Or alternatively to use a single container to preserve any data during development:
+
+    docker run -d -p 9944:9944 --name node universaldot/node:develop
+
 <!-- 
 Then run the following command to start a single node development chain.
 


### PR DESCRIPTION
Added `publish.yml` workflow for building a Docker image (`linux/amd64`,`linux/arm64`) and pushing to Docker hub with tag of `universaldot/node:develop`.

Added multi-stage Dockerfile to minimize image size
  - Stage 1: `base` - uses Rust nightly, adds wasm target along with required packages and cargo-chef to simplify project dependency caching
    - `base-amd64` triggered when target platform is `amd64`, setting `ARCH` environment variable to `x86_64` used by Rust
    - `base-arm64` triggered when target platform is `arm64`, setting `ARCH` environment variable to `aarch64` used by Rust
  - Stage 2: `planner` - uses cargo-chef to prepare a `recipe.json` file, listing all dependencies in project
  - Stage 3: `builder` 
    - sets up environment for particular target architecture (e.g. `FROM base-arm64`), installing required packages for cross-compilation
    - copies `recipe.json` file from `planner` stage and compiles dependencies for target platform (separate command for Docker layer caching)
    - compiles application for target platform
  - Stage 4: `runtime` - copies resulting binary from `builder` stage, sets startup command and exposes port
  - Stage 5: 'metadata' - sets metadata on resulting image 

Finally, you can start up a container using `docker run -it --rm -p 9944:9944  universaldot/node:develop`. Tested on both amd64 and arm64 devices.

PS - initial workflow run took ~1h10m, expect subsequent runs to be faster due to layer caching.