### PR TITLE
Add check.sh to ease local CI checks

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,1 @@
+SKIP_WASM_BUILD=1 cargo clippy --features=default,runtime-benchmarks --release && cargo test --release


### PR DESCRIPTION
Been meaning to add this suggestion since the beginning as I got caught out by the benchmarks. 

    ./scripts/check.sh

The script basically emulates `.github/workflows/check.yml`, as well as runs all tests if the checks are successful. The idea being a quick run locally before pushing, saving having to wait 10-20 mins before finding out something was missed.