### PR TITLE
Tag docker image according to branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,9 @@ on:
   # Triggers the workflow on push (only for the develop branch)
   push:
     branches: [ universal-master, universal-develop ]
-
+  # Triggers on a release being published
+  release:
+    types: [ published ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -31,8 +33,10 @@ jobs:
 
       - name: Build and push
         uses: docker/build-push-action@v3
+        env:
+          TAG: universaldot/node
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: universaldot/node:${{ github.ref == 'refs/heads/universal-master' && 'latest' || 'develop' }}
+          tags: ${{ format('{0}:{1}{2}', env.TAG, github.ref == 'refs/heads/universal-master' && 'latest' || 'develop', github.event.release.tag_name != '' && format(',{0}:{1}', env.TAG, github.event.release.tag_name) || '') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ name: Publish Docker Image
 on:
   # Triggers the workflow on push (only for the develop branch)
   push:
-    branches: [ universal-develop ]
+    branches: [ universal-master, universal-develop ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -35,4 +35,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: universaldot/node:develop
+          tags: universaldot/node:${{ github.ref == 'refs/heads/universal-master' && 'latest' || 'develop' }}


### PR DESCRIPTION
Updated workflow includes:
- pushes to master branch, tagging the image as `latest` when branch is `universal-master`, otherwise `develop`
- Adds a tag on release publish, using the Git release tag name

Note: the workflow uses `format()` to set a comma separated list of tags. The release/version tag should only be added when a release is published, otherwise the only tag should be `latest` or `develop`.