### PR TITLE
Fixes of various outstanding items after merge with upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3815,6 +3815,7 @@ dependencies = [
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-api",
@@ -4278,6 +4279,22 @@ dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-runtime",
+]
+
+[[package]]
+name = "pallet-treasury"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.27#8eff668a42325aeb4433eace1604f4d286a6ec05"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/pallets/dao/src/lib.rs
+++ b/pallets/dao/src/lib.rs
@@ -224,7 +224,6 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn members)]
-	#[pallet::unbounded]
 	/// Create members of organization storage map with key: Hash and value: BoundedVec<AccountID>
 	pub(super) type Members<T: Config> = StorageMap<_, Twox64Concat, T::Hash, BoundedMemberPerOrg<T>, ValueQuery>;
 
@@ -235,13 +234,11 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn member_of)]
-	#[pallet::unbounded]
 	/// Storage item that indicates which DAO's a user belongs to [AccountID, BoundedVec<OrganisationId>]
 	pub(super) type MemberOf<T: Config> = StorageMap<_, Twox64Concat, T::AccountId, BoundedOrgPerMember<T>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn applicants_to_organization)]
-	#[pallet::unbounded]
 	/// Storage Map to indicate which user agree with a proposed Vision of an Organisation [OrganizationId, BoundedVec[Account]]
 	pub(super) type ApplicantsToOrganization<T: Config> = StorageMap<_, Twox64Concat, OrganizationIdOf<T>, BoundedApplicantsPerOrg<T>, ValueQuery>;
 

--- a/pallets/dao/src/mock.rs
+++ b/pallets/dao/src/mock.rs
@@ -76,6 +76,8 @@ impl pallet_timestamp::Config for Test {
 
 parameter_types! {
 	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxDelegateTypeLen: u32 = 64;
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
 	pub const MaxNameLen: u32 = 64;
 	#[derive(TypeInfo, MaxEncodedLen, Encode)]
 	pub const MaxValueLen: u32 = 64;
@@ -83,6 +85,8 @@ parameter_types! {
 
 impl pallet_did::Config for Test {
 	type Event = Event;
+	type DelegateType = ();
+	type MaxDelegateTypeLen = MaxDelegateTypeLen;
 	type MaxNameLen = MaxNameLen;
 	type MaxValueLen = MaxValueLen;
 	type Public = sr25519::Public;

--- a/pallets/did/src/benchmarking.rs
+++ b/pallets/did/src/benchmarking.rs
@@ -22,7 +22,7 @@ benchmarks! {
     add_delegate {
         let caller = make_caller!(T);
         let delegate:T::AccountId = account("delegate", 0, 0);
-    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), delegate, Vec::new(), Some(T::BlockNumber::one()))
+    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), delegate, BoundedVec::default(), Some(T::BlockNumber::one()))
 
     change_owner {
         let caller = make_caller!(T);
@@ -33,26 +33,26 @@ benchmarks! {
     revoke_delegate {
         let caller = make_caller!(T);
         let delegate:T::AccountId = account("delegate", 0, 0);
-        let _ = Did::<T>::add_delegate(RawOrigin::Signed(caller.clone()).into(), caller.clone(), delegate.clone(), Vec::new(), None);
-    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), Vec::new(), delegate)
+        let _ = Did::<T>::add_delegate(RawOrigin::Signed(caller.clone()).into(), caller.clone(), delegate.clone(), BoundedVec::default(), None);
+    }: _(RawOrigin::Signed(caller.clone()), caller.clone(), BoundedVec::default(), delegate)
 
     add_attribute {
         let caller = make_caller!(T);
-        let name = b"name1".to_vec();
-        let value = b"value1".to_vec();
+        let name : BoundedNameOf<T> = b"name1".to_vec().try_into().unwrap();
+        let value : BoundedValueOf<T> = b"value1".to_vec().try_into().unwrap();
     }: _(RawOrigin::Signed(caller.clone()), caller.clone(), name, value, Some(T::BlockNumber::one()))
 
     revoke_attribute {
         let caller = make_caller!(T);
-        let name = b"name1".to_vec();
-        let value = b"value1".to_vec();
+        let name : BoundedNameOf<T> = b"name1".to_vec().try_into().unwrap();
+        let value : BoundedValueOf<T> = b"value1".to_vec().try_into().unwrap();
         let _ = Did::<T>::add_attribute(RawOrigin::Signed(caller.clone()).into(), caller.clone(), name.clone(), value, None);
     }: _(RawOrigin::Signed(caller.clone()), caller.clone(), name)
 
     delete_attribute {
         let caller = make_caller!(T);
-        let name = b"name1".to_vec();
-        let value = b"value1".to_vec();
+        let name : BoundedNameOf<T> = b"name1".to_vec().try_into().unwrap();
+        let value : BoundedValueOf<T> = b"value1".to_vec().try_into().unwrap();
         let _ = Did::<T>::add_attribute(RawOrigin::Signed(caller.clone()).into(), caller.clone(), name.clone(), value, None);
     }: _(RawOrigin::Signed(caller.clone()), caller.clone(), name)
 }

--- a/pallets/did/src/did.rs
+++ b/pallets/did/src/did.rs
@@ -2,24 +2,24 @@ use crate::types::AttributedId;
 
 use frame_support::dispatch::DispatchResult;
 
-pub trait Did<AccountId, BlockNumber, Moment, Signature, BoundedName, BoundedLen> {
+pub trait Did<AccountId, BlockNumber, Moment, Signature, BoundedName, BoundedValue, BoundedDelegateType> {
     fn is_owner(identity: &AccountId, actual_owner: &AccountId) -> DispatchResult;
     fn identity_owner(identity: &AccountId) -> AccountId;
     fn valid_delegate(
         identity: &AccountId,
-        delegate_type: &[u8],
+        delegate_type: &BoundedDelegateType,
         delegate: &AccountId,
     ) -> DispatchResult;
     fn valid_listed_delegate(
         identity: &AccountId,
-        delegate_type: &[u8],
+        delegate_type: &BoundedDelegateType,
         delegate: &AccountId,
     ) -> DispatchResult;
     fn create_delegate(
         who: &AccountId,
         identity: &AccountId,
         delegate: &AccountId,
-        delegate_type: &[u8],
+        delegate_type: &BoundedDelegateType,
         valid_for: Option<BlockNumber>,
     ) -> DispatchResult;
     fn check_signature(signature: &Signature, msg: &[u8], signer: &AccountId) -> DispatchResult;
@@ -32,14 +32,11 @@ pub trait Did<AccountId, BlockNumber, Moment, Signature, BoundedName, BoundedLen
     fn create_attribute(
         who: &AccountId,
         identity: &AccountId,
-        name: &[u8],
-        value: &[u8],
+        name: &BoundedName,
+        value: &BoundedValue,
         valid_for: Option<BlockNumber>,
     ) -> DispatchResult;
-    fn reset_attribute(who: AccountId, identity: &AccountId, name: &[u8]) -> DispatchResult;
-    fn valid_attribute(identity: &AccountId, name: &[u8], value: &[u8]) -> DispatchResult;
-    fn attribute_and_id(
-        identity: &AccountId,
-        name: &[u8],
-    ) -> Option<AttributedId<BlockNumber, Moment, BoundedName, BoundedLen>>;
+    fn reset_attribute(who: AccountId, identity: &AccountId, name: &BoundedName) -> DispatchResult;
+    fn valid_attribute(identity: &AccountId, name: &BoundedName, value: &BoundedValue) -> DispatchResult;
+    fn attribute_and_id(identity: &AccountId, name: &BoundedName) -> Option<AttributedId<BlockNumber, Moment, BoundedName, BoundedValue>>;
 }

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -140,7 +140,6 @@ pub mod pallet {
     /// Attribute nonce used to generate a unique hash even if the attribute is deleted and recreated.
     #[pallet::storage]
     #[pallet::getter(fn nonce_of)]
-    #[pallet::unbounded]
     pub type AttributeNonce<T: Config> = StorageMap<_, Twox64Concat, (T::AccountId, BoundedNameOf<T>), u64>;
 
     /// Identity owner.
@@ -613,7 +612,6 @@ for Pallet<T>
 
     /// Validates if an attribute belongs to an identity and it has not expired.
     fn valid_attribute(identity: &T::AccountId, name: &BoundedNameOf<T>, value: &BoundedValueOf<T>) -> DispatchResult {
-        ensure!(name.len() <= 64, Error::<T>::InvalidAttribute);
         let result = Self::attribute_and_id(identity, name);
 
         let (attr, _) = match result {

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -21,7 +21,7 @@ use frame_support::{dispatch::DispatchResult, ensure, traits::Time};
 use frame_system::ensure_signed;
 pub use pallet::*;
 use sp_io::hashing::blake2_256;
-use sp_runtime::traits::{IdentifyAccount, Verify};
+use sp_runtime::traits::{Get, IdentifyAccount, Verify};
 use sp_std::prelude::*;
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -44,6 +44,7 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+type BoundedDelegateTypeOf<T> = BoundedVec<u8, <T as Config>::MaxDelegateTypeLen>;
 type BoundedNameOf<T> = BoundedVec<u8, <T as Config>::MaxNameLen>;
 type BoundedValueOf<T> = BoundedVec<u8, <T as Config>::MaxValueLen>;
 
@@ -69,6 +70,13 @@ pub mod pallet {
         // /// The origin which may forcibly set or remove a name. Root can always do this.
         // type ForceOrigin: EnsureOrigin<Self::Origin>;
 
+        /// The default delegate type.
+        type DelegateType: Get<BoundedVec<u8, Self::MaxDelegateTypeLen>>;
+
+        /// A bound on the maximum length of a delegate type.
+        #[pallet::constant]
+        type MaxDelegateTypeLen: Get<u32> + MaxEncodedLen + TypeInfo;
+
         /// A bound on name field of Attribute/AttributeTransaction structs.
         #[pallet::constant]
         type MaxNameLen: Get<u32> + MaxEncodedLen + TypeInfo;
@@ -91,7 +99,6 @@ pub mod pallet {
         AlreadyExists,
         InvalidDelegate,
         BadSignature,
-        AttributeNameTooLong,
         AttributeCreationFailed,
         AttributeResetFailed,
         AttributeRemovalFailed,
@@ -100,7 +107,6 @@ pub mod pallet {
         Overflow,
         BadTransaction,
         TransactionNameTooLong,
-        AttributeValueTooLong,
     }
 
     #[pallet::event]
@@ -108,20 +114,18 @@ pub mod pallet {
     // #[pallet::metadata(T::AccountId = "AccountId", T::Balance = "Balance", T::Signature = "Signature", T::BlockNumber = "BlockNumber")]
     pub enum Event<T: Config> {
         OwnerChanged(T::AccountId, T::AccountId, T::AccountId, T::BlockNumber),
-        DelegateAdded(T::AccountId, Vec<u8>, T::AccountId, Option<T::BlockNumber>),
-        DelegateRevoked(T::AccountId, Vec<u8>, T::AccountId),
-        AttributeAdded(T::AccountId, Vec<u8>, Option<T::BlockNumber>),
-        AttributeRevoked(T::AccountId, Vec<u8>, T::BlockNumber),
-        AttributeDeleted(T::AccountId, Vec<u8>, T::BlockNumber),
+        DelegateAdded(T::AccountId, BoundedDelegateTypeOf<T>, T::AccountId, Option<T::BlockNumber>),
+        DelegateRevoked(T::AccountId, BoundedDelegateTypeOf<T>, T::AccountId),
+        AttributeAdded(T::AccountId, BoundedNameOf<T>, Option<T::BlockNumber>),
+        AttributeRevoked(T::AccountId, BoundedNameOf<T>, T::BlockNumber),
+        AttributeDeleted(T::AccountId, BoundedNameOf<T>, T::BlockNumber),
         AttributeTransactionExecuted(AttributeTransaction<T::Signature, T::AccountId, BoundedNameOf<T>, BoundedValueOf<T>>),
     }
 
     /// Delegates are only valid for a specific period defined as blocks number.
     #[pallet::storage]
     #[pallet::getter(fn delegate_of)]
-    #[pallet::unbounded]
-    pub type DelegateOf<T: Config> =
-    StorageMap<_, Blake2_128Concat, (T::AccountId, Vec<u8>, T::AccountId), T::BlockNumber>;
+    pub type DelegateOf<T: Config> = StorageMap<_, Blake2_128Concat, (T::AccountId, BoundedDelegateTypeOf<T>, T::AccountId), T::BlockNumber>;
 
     // Attributes are only valid for a specific period defined as blocks number.
     #[pallet::storage]
@@ -137,7 +141,7 @@ pub mod pallet {
     #[pallet::storage]
     #[pallet::getter(fn nonce_of)]
     #[pallet::unbounded]
-    pub type AttributeNonce<T: Config> = StorageMap<_, Twox64Concat, (T::AccountId, Vec<u8>), u64>;
+    pub type AttributeNonce<T: Config> = StorageMap<_, Twox64Concat, (T::AccountId, BoundedNameOf<T>), u64>;
 
     /// Identity owner.
     #[pallet::storage]
@@ -172,7 +176,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             identity: T::AccountId,
             delegate: T::AccountId,
-            delegate_type: Vec<u8>,
+            delegate_type: BoundedDelegateTypeOf<T>,
             valid_for: Option<T::BlockNumber>,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
@@ -213,7 +217,7 @@ pub mod pallet {
         pub fn revoke_delegate(
             origin: OriginFor<T>,
             identity: T::AccountId,
-            delegate_type: Vec<u8>,
+            delegate_type: BoundedDelegateTypeOf<T>,
             delegate: T::AccountId,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
@@ -233,12 +237,11 @@ pub mod pallet {
         pub fn add_attribute(
             origin: OriginFor<T>,
             identity: T::AccountId,
-            name: Vec<u8>,
-            value: Vec<u8>,
+            name: BoundedNameOf<T>,
+            value: BoundedValueOf<T>,
             valid_for: Option<T::BlockNumber>,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
-            ensure!(name.len() <= 64, Error::<T>::AttributeNameTooLong);
 
             Self::create_attribute(&who, &identity, &name, &value, valid_for)?;
             Self::deposit_event(Event::AttributeAdded(identity, name, valid_for));
@@ -251,7 +254,7 @@ pub mod pallet {
         pub fn revoke_attribute(
             origin: OriginFor<T>,
             identity: T::AccountId,
-            name: Vec<u8>,
+            name: BoundedNameOf<T>,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
             ensure!(name.len() <= 64, Error::<T>::AttributeRemovalFailed);
@@ -270,7 +273,7 @@ pub mod pallet {
         pub fn delete_attribute(
             origin: OriginFor<T>,
             identity: T::AccountId,
-            name: Vec<u8>,
+            name: BoundedNameOf<T>,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
             Self::is_owner(&identity, &who)?;
@@ -350,9 +353,8 @@ pub mod pallet {
 /// The main implementation of this Did pallet.
 impl<T: Config> Pallet<T> {
     /// Get nonce for _identity_ and _name_.
-    ///
-    fn get_nonce(identity: &T::AccountId, name: &[u8]) -> u64 {
-        Self::nonce_of((&identity, name.to_vec())).unwrap_or(0u64)
+    fn get_nonce(identity: &T::AccountId, name: &BoundedNameOf<T>) -> u64 {
+        Self::nonce_of((&identity, name)).unwrap_or(0u64)
     }
 
     /// Set identity owner.
@@ -384,7 +386,7 @@ impl<T: Config> Pallet<T> {
     pub fn revoke_delegate_internal(
         who: &T::AccountId,
         identity: &T::AccountId,
-        delegate_type: &Vec<u8>,
+        delegate_type: &BoundedDelegateTypeOf<T>,
         delegate: &T::AccountId,
     ) {
         let now_timestamp = T::Time::now();
@@ -436,7 +438,7 @@ impl<T: Config> Pallet<T> {
 }
 
 impl<T: Config>
-Did<T::AccountId, T::BlockNumber, <<T as Config>::Time as Time>::Moment, T::Signature, BoundedNameOf<T>, BoundedValueOf<T>>
+Did<T::AccountId, T::BlockNumber, <<T as Config>::Time as Time>::Moment, T::Signature, BoundedNameOf<T>, BoundedValueOf<T>, BoundedDelegateTypeOf<T>>
 for Pallet<T>
 {
     /// Validates if the AccountId 'actual_owner' owns the identity.
@@ -462,7 +464,7 @@ for Pallet<T>
     /// return Ok if valid.
     fn valid_delegate(
         identity: &T::AccountId,
-        delegate_type: &[u8],
+        delegate_type: &BoundedDelegateTypeOf<T>,
         delegate: &T::AccountId,
     ) -> DispatchResult {
         ensure!(delegate_type.len() <= 64, Error::<T>::InvalidDelegate);
@@ -477,7 +479,7 @@ for Pallet<T>
     /// Validates that a delegate contains_key for specific purpose and remains valid at this block high.
     fn valid_listed_delegate(
         identity: &T::AccountId,
-        delegate_type: &[u8],
+        delegate_type: &BoundedDelegateTypeOf<T>,
         delegate: &T::AccountId,
     ) -> DispatchResult {
         ensure!(
@@ -492,12 +494,12 @@ for Pallet<T>
         }
     }
 
-    // Creates a new delegete for an account.
+    // Creates a new delegate for an account.
     fn create_delegate(
         who: &T::AccountId,
         identity: &T::AccountId,
         delegate: &T::AccountId,
-        delegate_type: &[u8],
+        delegate_type: &BoundedDelegateTypeOf<T>,
         valid_for: Option<T::BlockNumber>,
     ) -> DispatchResult {
         Self::is_owner(identity, who)?;
@@ -510,7 +512,7 @@ for Pallet<T>
         let now_block_number = <frame_system::Pallet<T>>::block_number();
         let validity: T::BlockNumber = match valid_for {
             Some(blocks) => now_block_number + blocks,
-            None => u32::max_value().into(),
+            None => u32::MAX.into(),
         };
 
         <DelegateOf<T>>::insert((&identity, delegate_type, delegate), &validity);
@@ -538,16 +540,16 @@ for Pallet<T>
         signer: &T::AccountId,
     ) -> DispatchResult {
         // Owner or a delegate signer.
-        Self::valid_delegate(identity, b"x25519VerificationKey2018", signer)?;
+        Self::valid_delegate(identity, &T::DelegateType::get(), signer)?;
         Self::check_signature(signature, msg, signer)
     }
 
-    /// Adds a new attribute to an identity and colects the storage fee.
+    /// Adds a new attribute to an identity and collects the storage fee.
     fn create_attribute(
         who: &T::AccountId,
         identity: &T::AccountId,
-        name: &[u8],
-        value: &[u8],
+        name: &BoundedNameOf<T>,
+        value: &BoundedValueOf<T>,
         valid_for: Option<T::BlockNumber>,
     ) -> DispatchResult {
         Self::is_owner(identity, who)?;
@@ -559,21 +561,15 @@ for Pallet<T>
             let now_block_number = <frame_system::Pallet<T>>::block_number();
             let validity: T::BlockNumber = match valid_for {
                 Some(blocks) => now_block_number + blocks,
-                None => u32::max_value().into(),
+                None => u32::MAX.into(),
             };
 
             let mut nonce = Self::get_nonce(identity, name);
 
-            // Workaround until whole pallet converted to use BoundedVec
-            let bounded_name: BoundedVec<_, _> =
-                name.to_vec().try_into().map_err(|()| Error::<T>::AttributeNameTooLong)?;
-            let bounded_value: BoundedVec<_, _> =
-                value.to_vec().try_into().map_err(|()| Error::<T>::AttributeValueTooLong)?;
-
             let id = (&identity, name, nonce).using_encoded(blake2_256);
             let new_attribute = Attribute {
-                name: bounded_name,
-                value: bounded_value,
+                name: name.clone(),
+                value: value.clone(),
                 validity,
                 creation: now_timestamp,
                 nonce,
@@ -584,14 +580,14 @@ for Pallet<T>
             <AttributeOf<T>>::insert((identity, &id), new_attribute);
 
             // update nonce
-            <AttributeNonce<T>>::mutate((identity, name.to_vec()), |n| *n = Some(nonce));
+            <AttributeNonce<T>>::mutate((identity, name), |n| *n = Some(nonce));
             <UpdatedBy<T>>::insert(identity, (who, now_block_number, now_timestamp));
             Ok(())
         }
     }
 
     /// Updates the attribute validity to make it expire and invalid.
-    fn reset_attribute(who: T::AccountId, identity: &T::AccountId, name: &[u8]) -> DispatchResult {
+    fn reset_attribute(who: T::AccountId, identity: &T::AccountId, name: &BoundedNameOf<T>) -> DispatchResult {
         Self::is_owner(identity, &who)?;
         // If the attribute contains_key, the latest valid block is set to the current block.
         let result = Self::attribute_and_id(identity, name);
@@ -616,7 +612,7 @@ for Pallet<T>
     }
 
     /// Validates if an attribute belongs to an identity and it has not expired.
-    fn valid_attribute(identity: &T::AccountId, name: &[u8], value: &[u8]) -> DispatchResult {
+    fn valid_attribute(identity: &T::AccountId, name: &BoundedNameOf<T>, value: &BoundedValueOf<T>) -> DispatchResult {
         ensure!(name.len() <= 64, Error::<T>::InvalidAttribute);
         let result = Self::attribute_and_id(identity, name);
 
@@ -625,8 +621,7 @@ for Pallet<T>
             None => return Err(Error::<T>::InvalidAttribute.into()),
         };
 
-        if (attr.validity > (<frame_system::Pallet<T>>::block_number()))
-            && (attr.value == value.to_vec())
+        if (attr.validity > (<frame_system::Pallet<T>>::block_number())) && (attr.value == *value)
         {
             Ok(())
         } else {
@@ -638,9 +633,9 @@ for Pallet<T>
     /// Uses a nonce to keep track of identifiers making them unique after attributes deletion.
     fn attribute_and_id(
         identity: &T::AccountId,
-        name: &[u8],
+        name: &BoundedNameOf<T>,
     ) -> Option<AttributedId<T::BlockNumber, <<T as Config>::Time as Time>::Moment, BoundedNameOf<T>, BoundedValueOf<T>>> {
-        let nonce = Self::nonce_of((&identity, name.to_vec())).unwrap_or(0u64);
+        let nonce = Self::nonce_of((&identity, name)).unwrap_or(0u64);
 
         // Used for first time attribute creation
         let lookup_nonce = match nonce {

--- a/pallets/did/src/mock.rs
+++ b/pallets/did/src/mock.rs
@@ -3,14 +3,10 @@ use frame_support::{parameter_types, weights::Weight, traits::Everything};
 use frame_system as system;
 use pallet_timestamp as timestamp;
 use sp_core::{sr25519, Pair, H256};
-use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
-    Perbill,
-    traits::ConstU32
-};
+use sp_runtime::{testing::Header, traits::{BlakeTwo256, IdentityLookup}, Perbill, traits::ConstU32, BoundedVec};
 use scale_info::TypeInfo;
 use codec::{Encode, MaxEncodedLen};
+use sp_runtime::traits::Get;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -72,6 +68,8 @@ impl timestamp::Config for Test {
 }
 
 parameter_types! {
+    #[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxDelegateTypeLen: u32 = 64;
 	#[derive(TypeInfo, MaxEncodedLen, Encode)]
 	pub const MaxNameLen: u32 = 64;
 	#[derive(TypeInfo, MaxEncodedLen, Encode)]
@@ -80,12 +78,22 @@ parameter_types! {
 
 impl Config for Test {
     type Event = Event;
+    type DelegateType = DelegateTypeProvider;
+    type MaxDelegateTypeLen = MaxDelegateTypeLen;
     type MaxNameLen = MaxNameLen;
     type MaxValueLen = MaxValueLen;
     type Public = sr25519::Public;
     type Signature = sr25519::Signature;
     type Time = Timestamp;
     type WeightInfo = pallet_did::weights::SubstrateWeight<Self>;
+}
+
+pub struct DelegateTypeProvider;
+impl Get<BoundedVec<u8, MaxDelegateTypeLen>> for DelegateTypeProvider {
+    // Provide the default delegate type as a BoundedVec
+    fn get() -> BoundedVec<u8, MaxDelegateTypeLen> {
+        b"x25519VerificationKey2018".to_vec().try_into().expect("could not convert delegate type into boundedvec")
+    }
 }
 
 pub type DID = Pallet<Test>;

--- a/pallets/grant/src/lib.rs
+++ b/pallets/grant/src/lib.rs
@@ -252,8 +252,6 @@ pub mod pallet {
 
 
 		// Generates treasury account
-		// todo: ensure that usage of into_account_truncating is correct
-		// See: https://paritytech.github.io/substrate/master/sp_runtime/traits/trait.AccountIdConversion.html#tymethod.into_sub_account_truncating
 		pub(crate) fn account_id() -> T::AccountId {
 			T::PalletId::get().into_account_truncating()
 		}

--- a/pallets/task/src/lib.rs
+++ b/pallets/task/src/lib.rs
@@ -873,8 +873,6 @@ pub mod pallet {
 		}
 
 		// Function that generates escrow account based on TaskID
-		// todo: ensure that usage of into_account_truncating is correct
-		// See: https://paritytech.github.io/substrate/master/sp_runtime/traits/trait.AccountIdConversion.html#tymethod.into_sub_account_truncating
 		#[allow(dead_code)] // Used in test only
 		pub(crate) fn account_id(task_id: &T::Hash) -> T::AccountId {
 			T::PalletId::get().into_sub_account_truncating(task_id)

--- a/pallets/task/src/mock.rs
+++ b/pallets/task/src/mock.rs
@@ -122,6 +122,8 @@ impl pallet_dao::Config for Test {
 
 parameter_types! {
 	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxDelegateTypeLen: u32 = 64;
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
 	pub const MaxNameLen: u32 = 64;
 	#[derive(TypeInfo, MaxEncodedLen, Encode)]
 	pub const MaxValueLen: u32 = 64;
@@ -129,6 +131,8 @@ parameter_types! {
 
 impl pallet_did::Config for Test {
 	type Event = Event;
+	type DelegateType = ();
+	type MaxDelegateTypeLen = MaxDelegateTypeLen;
 	type MaxNameLen = MaxNameLen;
 	type MaxValueLen = MaxValueLen;
 	type Public = sr25519::Public;

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -1,5 +1,5 @@
 // Ripped from polkadot/common/src/impls.rs
-use frame_support::traits::{Currency, Imbalance, OnUnbalanced};
+use frame_support::traits::{Imbalance, OnUnbalanced};
 use pallet_balances::NegativeImbalance;
 
 /// Logic for the author to get a portion of fees.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -319,16 +319,28 @@ impl pallet_task::traits::Organization<Hash> for Runtime {
 	}
 }
 
+parameter_types! {
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const DunbarsNumber: u32 = 150;
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxDescriptionLen: u32 = 500;
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const DaoMaxNameLen: u32 = 100;
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxVisionLen: u32 = 46; // CID's in IPFS are 46 characters long
+	#[derive(TypeInfo, MaxEncodedLen, Encode)]
+	pub const MaxApplicantsToOrganisation: u32 = 1_000;
+}
+
 // Configure the pallet-dao.
 impl pallet_dao::Config for Runtime {
 	type Event = Event;
-	// todo: set lengths
-	type MaxDescriptionLen =();
-	type MaxNameLen = ();
-	type MaxVisionLen = ();
-	type MaxMembersPerOrganisation = ();
-	type MaxOrganisationsPerMember = ();
-	type MaxApplicantsToOrganisation = ();
+	type MaxDescriptionLen = MaxDescriptionLen;
+	type MaxNameLen = DaoMaxNameLen;
+	type MaxVisionLen = MaxVisionLen;
+	type MaxMembersPerOrganisation = DunbarsNumber;
+	type MaxOrganisationsPerMember = DunbarsNumber;
+	type MaxApplicantsToOrganisation = MaxApplicantsToOrganisation;
 	type WeightInfo = pallet_dao::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -498,7 +498,11 @@ mod benches {
 		[frame_system, SystemBench::<Runtime>]
 		[pallet_balances, Balances]
 		[pallet_timestamp, Timestamp]
-		[pallet_template, TemplateModule]
+		[pallet_profile, Profile]
+		[pallet_task, Task]
+		[pallet_dao, Dao]
+		[pallet_grant, Grant]
+		[pallet_did, Did]
 	);
 }
 
@@ -645,18 +649,9 @@ impl_runtime_apis! {
 			use baseline::Pallet as BaselineBench;
 
 			let mut list = Vec::<BenchmarkList>::new();
-			// todo: use https://paritytech.github.io/substrate/master/node_template_runtime/macro.list_benchmarks.html
-			// list_benchmarks!(list, extra);
+			list_benchmarks!(list, extra);
 
-			list_benchmark!(list, extra, frame_benchmarking, BaselineBench::<Runtime>);
-			list_benchmark!(list, extra, frame_system, SystemBench::<Runtime>);
-			list_benchmark!(list, extra, pallet_balances, Balances);
-			list_benchmark!(list, extra, pallet_timestamp, Timestamp);
-			list_benchmark!(list, extra, pallet_profile, Profile);
-			list_benchmark!(list, extra, pallet_task, Task);
-			list_benchmark!(list, extra, pallet_dao, Dao);
-			list_benchmark!(list, extra, pallet_grant, Grant);
-			list_benchmark!(list, extra, pallet_did, Did);
+			// Note: benchmark definitions moved to benches::define_benchmarks! above
 
 			let storage_info = AllPalletsWithSystem::storage_info();
 
@@ -689,20 +684,9 @@ impl_runtime_apis! {
 
 			let mut batches = Vec::<BenchmarkBatch>::new();
 			let params = (&config, &whitelist);
+			add_benchmarks!(params, batches);
 
-			// todo: use https://paritytech.github.io/substrate/master/node_template_runtime/macro.add_benchmarks.html
-			// add_benchmarks!(params, batches);
-
-			add_benchmark!(params, batches, frame_benchmarking, BaselineBench::<Runtime>);
-			add_benchmark!(params, batches, frame_system, SystemBench::<Runtime>);
-			add_benchmark!(params, batches, pallet_balances, Balances);
-			add_benchmark!(params, batches, pallet_timestamp, Timestamp);
-			add_benchmark!(params, batches, pallet_profile, Profile);
-			add_benchmark!(params, batches, pallet_task, Task);
-			add_benchmark!(params, batches, pallet_dao, Dao);
-			add_benchmark!(params, batches, pallet_grant, Grant);
-			add_benchmark!(params, batches, pallet_did, Did);
-
+			// Note: benchmark definitions moved to benches::define_benchmarks! above
 
 			Ok(batches)
 		}


### PR DESCRIPTION
- Added missing Dao config to runtime
- Moved runtime benchmark definitions to `define_benchmarks`, as per upstream. This allows them to be defined in a single place.
- Removed unnecessary unbounded attribute macros
- Updated cargo.lock with missing `treasury` pallet
- Replaced unbounded vectors in `did` pallet with bounded, removing checks/tests which were no longer necessary
  - Added a bound for delegate type length to config
  - Added the default delegate type to config for definition of value in runtime/mock